### PR TITLE
fix(service json consumption): Fix for content_type param

### DIFF
--- a/lib/ibm_watson/personality_insights_v3.rb
+++ b/lib/ibm_watson/personality_insights_v3.rb
@@ -241,7 +241,7 @@ module IBMWatson
         "csv_headers" => csv_headers,
         "consumption_preferences" => consumption_preferences
       }
-      if content_type == "application/json" && content.instance_of?(Hash)
+      if content_type.start_with?("application/json") && content.instance_of?(Hash)
         data = content.to_json
       else
         data = content

--- a/lib/ibm_watson/tone_analyzer_v3.rb
+++ b/lib/ibm_watson/tone_analyzer_v3.rb
@@ -214,7 +214,7 @@ module IBMWatson
         "sentences" => sentences,
         "tones" => tones.to_a
       }
-      if content_type == "application/json" && tone_input.instance_of?(Hash)
+      if content_type.start_with?("application/json") && tone_input.instance_of?(Hash)
         data = tone_input.to_json
       else
         data = tone_input


### PR DESCRIPTION
* Previously, if a content_type was given as `"application/json;charset=utf-8"`, it would not have been interpreted as an `application/json` input. These changes should address this