### PR TITLE
Add ability to configure the http client

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,7 @@
 [bumpversion]
 current_version = 0.2.0
 commit = True
+message = [skip ci] Bump version: {current_version} -> {new_version}
 
 [bumpversion:file:lib/ibm_watson/version.rb]
 search = {current_version}

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Result: "<response returned by service>"
 ```
 
 ## Configuring the http client
-To set client configs like timeout or proxy use the `http_config` function and pass in the configurations.
+To set client configs like timeout or proxy use the `configure_http_client` function and pass in the configurations.
 
 ```ruby
 require "ibm_watson/assistant_v1"
@@ -225,7 +225,7 @@ assistant = AssistantV1.new(
   version: "2018-07-10"
 )
 
-assistant.http_config(
+assistant.configure_http_client(
   timeout: {
     # Accepts either :per_operation or :global
     per_operation: { # The individual timeouts for each operation

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ assistant = AssistantV1.new(
 
 assistant.http_config(
   timeout: {
+    # Accepts either :per_operation or :global
     per_operation: { # The individual timeouts for each operation
       read: 5,
       write: 7,

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Ruby gem to quickly get started with the various [IBM Watson][wdc] services.
   * [Sending requests asynchronously](#sending-requests-asynchronously)
   * [Sending request headers](#sending-request-headers)
   * [Parsing HTTP response info](#parsing-http-response-info)
+  * [Configuring the http client](#configuring-the-http-client)
   * [Using Websockets](#using-websockets)
   * [Ruby version](#ruby-version)
   * [Contributing](#contributing)
@@ -71,9 +72,9 @@ Watson services are migrating to token-based Identity and Access Management (IAM
 To find out which authentication to use, view the service credentials. You find the service credentials for authentication the same way for all Watson services:
 
 1.  Go to the IBM Cloud **[Dashboard][watson-dashboard]** page.
-1.  Either click an existing Watson service instance or click **Create**.
-1.  Click **Show** to view your service credentials.
-1.  Copy the `url` and either `apikey` or `username` and `password`.
+2.  Either click an existing Watson service instance or click **Create**.
+3.  Click **Show** to view your service credentials.
+4.  Copy the `url` and either `apikey` or `username` and `password`.
 
 ### IAM
 
@@ -209,6 +210,40 @@ This would give an output of `DetailedResponse` having the structure:
 Status: 200
 Headers: "<http response headers>"
 Result: "<response returned by service>"
+```
+
+## Configuring the http client
+To set client configs like timeout or proxy use the `http_config` function and pass in the configurations.
+
+```ruby
+require "ibm_watson/assistant_v1"
+include IBMWatson
+
+assistant = AssistantV1.new(
+  username: "{username}",
+  password: "{password}",
+  version: "2018-07-10"
+)
+
+assistant.http_config(
+  timeout: {
+    per_operation: { # The individual timeouts for each operation
+      read: 5,
+      write: 7,
+      connect: 10
+    }
+    # global: 30 # The total timeout time
+  },
+  proxy: {
+    address: "bogus_address.com",
+    port: 9999,
+    username: "username",
+    password: "password",
+    headers: {
+      bogus_header: true
+    }
+  }
+)
 ```
 
 ## Using Websockets

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Ruby gem to quickly get started with the various [IBM Watson][wdc] services.
   * [Sending requests asynchronously](#sending-requests-asynchronously)
   * [Sending request headers](#sending-request-headers)
   * [Parsing HTTP response info](#parsing-http-response-info)
-  * [Configuring the http client](#configuring-the-http-client)
+  * [Configuring the HTTP client](#configuring-the-http-client)
   * [Using Websockets](#using-websockets)
   * [Ruby version](#ruby-version)
   * [Contributing](#contributing)
@@ -212,7 +212,7 @@ Headers: "<http response headers>"
 Result: "<response returned by service>"
 ```
 
-## Configuring the http client
+## Configuring the HTTP client
 To set client configs like timeout or proxy use the `configure_http_client` function and pass in the configurations.
 
 ```ruby

--- a/lib/ibm_watson/assistant_v1.rb
+++ b/lib/ibm_watson/assistant_v1.rb
@@ -68,6 +68,12 @@ module IBMWatson
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
     #   'https://iam.ng.bluemix.net/identity/token'.
+    # @option args x_watson_learning_opt_out [Boolean] Set to `true` to opt-out of data collection.
+    #   By default, all IBM Watson services log requests and their results.
+    #   Logging is done only to improve the services for future users. The logged data
+    #   is not shared or made public. If you are concerned with protecting the
+    #   privacy of users' personal information or otherwise do not want
+    #   your requests to be logged, you can opt out of logging.
     def initialize(args = {})
       @__async_initialized__ = false
       super()
@@ -79,6 +85,7 @@ module IBMWatson
       defaults[:iam_apikey] = nil
       defaults[:iam_access_token] = nil
       defaults[:iam_url] = nil
+      defaults[:x_watson_learning_opt_out] = false
       args = defaults.merge(args)
       @watson_service = WatsonService.new(
         vcap_services_name: "conversation",
@@ -88,6 +95,7 @@ module IBMWatson
         iam_apikey: args[:iam_apikey],
         iam_access_token: args[:iam_access_token],
         iam_url: args[:iam_url],
+        x_watson_learning_opt_out: args[:x_watson_learning_opt_out],
         use_vcap_services: true
       )
       @version = args[:version]
@@ -141,6 +149,21 @@ module IBMWatson
 
     def url
       @watson_service.url
+    end
+
+    # @!method http_config(proxy: {}, timeout: {})
+    # Sets the http client config, currently works with timeout and proxies
+    # @param proxy [Hash] The hash of proxy configurations
+    # @option proxy address [String] The address of the proxy
+    # @option proxy port [Integer] The port of the proxy
+    # @option proxy username [String] The username of the proxy, if authentication is needed
+    # @option proxy password [String] The password of the proxy, if authentication is needed
+    # @option proxy headers [Hash] The headers to be used with the proxy
+    # @param timeout [Hash] The hash for configuring timeouts. `per_operation` has priority over `global`
+    # @option timeout per_operation [Hash] Timeouts per operation. Requires `read`, `write`, `connect`
+    # @option timeout global [Integer] Upper bound on total request time
+    def http_config(proxy: {}, timeout: {})
+      @watson_service.http_config(proxy: proxy, timeout: timeout)
     end
     # :nocov:
     #########################

--- a/lib/ibm_watson/assistant_v1.rb
+++ b/lib/ibm_watson/assistant_v1.rb
@@ -151,7 +151,7 @@ module IBMWatson
       @watson_service.url
     end
 
-    # @!method http_config(proxy: {}, timeout: {})
+    # @!method configure_http_client(proxy: {}, timeout: {})
     # Sets the http client config, currently works with timeout and proxies
     # @param proxy [Hash] The hash of proxy configurations
     # @option proxy address [String] The address of the proxy
@@ -162,8 +162,8 @@ module IBMWatson
     # @param timeout [Hash] The hash for configuring timeouts. `per_operation` has priority over `global`
     # @option timeout per_operation [Hash] Timeouts per operation. Requires `read`, `write`, `connect`
     # @option timeout global [Integer] Upper bound on total request time
-    def http_config(proxy: {}, timeout: {})
-      @watson_service.http_config(proxy: proxy, timeout: timeout)
+    def configure_http_client(proxy: {}, timeout: {})
+      @watson_service.configure_http_client(proxy: proxy, timeout: timeout)
     end
     # :nocov:
     #########################

--- a/lib/ibm_watson/assistant_v1.rb
+++ b/lib/ibm_watson/assistant_v1.rb
@@ -68,12 +68,6 @@ module IBMWatson
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
     #   'https://iam.ng.bluemix.net/identity/token'.
-    # @option args x_watson_learning_opt_out [Boolean] Set to `true` to opt-out of data collection.
-    #   By default, all IBM Watson services log requests and their results.
-    #   Logging is done only to improve the services for future users. The logged data
-    #   is not shared or made public. If you are concerned with protecting the
-    #   privacy of users' personal information or otherwise do not want
-    #   your requests to be logged, you can opt out of logging.
     def initialize(args = {})
       @__async_initialized__ = false
       super()
@@ -85,7 +79,6 @@ module IBMWatson
       defaults[:iam_apikey] = nil
       defaults[:iam_access_token] = nil
       defaults[:iam_url] = nil
-      defaults[:x_watson_learning_opt_out] = false
       args = defaults.merge(args)
       @watson_service = WatsonService.new(
         vcap_services_name: "conversation",
@@ -95,7 +88,6 @@ module IBMWatson
         iam_apikey: args[:iam_apikey],
         iam_access_token: args[:iam_access_token],
         iam_url: args[:iam_url],
-        x_watson_learning_opt_out: args[:x_watson_learning_opt_out],
         use_vcap_services: true
       )
       @version = args[:version]

--- a/lib/ibm_watson/discovery_v1.rb
+++ b/lib/ibm_watson/discovery_v1.rb
@@ -70,12 +70,6 @@ module IBMWatson
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
     #   'https://iam.ng.bluemix.net/identity/token'.
-    # @option args x_watson_learning_opt_out [Boolean] Set to `true` to opt-out of data collection.
-    #   By default, all IBM Watson services log requests and their results.
-    #   Logging is done only to improve the services for future users. The logged data
-    #   is not shared or made public. If you are concerned with protecting the
-    #   privacy of users' personal information or otherwise do not want
-    #   your requests to be logged, you can opt out of logging.
     def initialize(args = {})
       @__async_initialized__ = false
       super()
@@ -87,7 +81,6 @@ module IBMWatson
       defaults[:iam_apikey] = nil
       defaults[:iam_access_token] = nil
       defaults[:iam_url] = nil
-      defaults[:x_watson_learning_opt_out] = false
       args = defaults.merge(args)
       @watson_service = WatsonService.new(
         vcap_services_name: "discovery",
@@ -97,7 +90,6 @@ module IBMWatson
         iam_apikey: args[:iam_apikey],
         iam_access_token: args[:iam_access_token],
         iam_url: args[:iam_url],
-        x_watson_learning_opt_out: args[:x_watson_learning_opt_out],
         use_vcap_services: true
       )
       @version = args[:version]

--- a/lib/ibm_watson/discovery_v1.rb
+++ b/lib/ibm_watson/discovery_v1.rb
@@ -153,7 +153,7 @@ module IBMWatson
       @watson_service.url
     end
 
-    # @!method http_config(proxy: {}, timeout: {})
+    # @!method configure_http_client(proxy: {}, timeout: {})
     # Sets the http client config, currently works with timeout and proxies
     # @param proxy [Hash] The hash of proxy configurations
     # @option proxy address [String] The address of the proxy
@@ -164,8 +164,8 @@ module IBMWatson
     # @param timeout [Hash] The hash for configuring timeouts. `per_operation` has priority over `global`
     # @option timeout per_operation [Hash] Timeouts per operation. Requires `read`, `write`, `connect`
     # @option timeout global [Integer] Upper bound on total request time
-    def http_config(proxy: {}, timeout: {})
-      @watson_service.http_config(proxy: proxy, timeout: timeout)
+    def configure_http_client(proxy: {}, timeout: {})
+      @watson_service.configure_http_client(proxy: proxy, timeout: timeout)
     end
     # :nocov:
     #########################

--- a/lib/ibm_watson/discovery_v1.rb
+++ b/lib/ibm_watson/discovery_v1.rb
@@ -70,6 +70,12 @@ module IBMWatson
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
     #   'https://iam.ng.bluemix.net/identity/token'.
+    # @option args x_watson_learning_opt_out [Boolean] Set to `true` to opt-out of data collection.
+    #   By default, all IBM Watson services log requests and their results.
+    #   Logging is done only to improve the services for future users. The logged data
+    #   is not shared or made public. If you are concerned with protecting the
+    #   privacy of users' personal information or otherwise do not want
+    #   your requests to be logged, you can opt out of logging.
     def initialize(args = {})
       @__async_initialized__ = false
       super()
@@ -81,6 +87,7 @@ module IBMWatson
       defaults[:iam_apikey] = nil
       defaults[:iam_access_token] = nil
       defaults[:iam_url] = nil
+      defaults[:x_watson_learning_opt_out] = false
       args = defaults.merge(args)
       @watson_service = WatsonService.new(
         vcap_services_name: "discovery",
@@ -90,6 +97,7 @@ module IBMWatson
         iam_apikey: args[:iam_apikey],
         iam_access_token: args[:iam_access_token],
         iam_url: args[:iam_url],
+        x_watson_learning_opt_out: args[:x_watson_learning_opt_out],
         use_vcap_services: true
       )
       @version = args[:version]
@@ -143,6 +151,21 @@ module IBMWatson
 
     def url
       @watson_service.url
+    end
+
+    # @!method http_config(proxy: {}, timeout: {})
+    # Sets the http client config, currently works with timeout and proxies
+    # @param proxy [Hash] The hash of proxy configurations
+    # @option proxy address [String] The address of the proxy
+    # @option proxy port [Integer] The port of the proxy
+    # @option proxy username [String] The username of the proxy, if authentication is needed
+    # @option proxy password [String] The password of the proxy, if authentication is needed
+    # @option proxy headers [Hash] The headers to be used with the proxy
+    # @param timeout [Hash] The hash for configuring timeouts. `per_operation` has priority over `global`
+    # @option timeout per_operation [Hash] Timeouts per operation. Requires `read`, `write`, `connect`
+    # @option timeout global [Integer] Upper bound on total request time
+    def http_config(proxy: {}, timeout: {})
+      @watson_service.http_config(proxy: proxy, timeout: timeout)
     end
     # :nocov:
     #########################

--- a/lib/ibm_watson/language_translator_v3.rb
+++ b/lib/ibm_watson/language_translator_v3.rb
@@ -70,12 +70,6 @@ module IBMWatson
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
     #   'https://iam.ng.bluemix.net/identity/token'.
-    # @option args x_watson_learning_opt_out [Boolean] Set to `true` to opt-out of data collection.
-    #   By default, all IBM Watson services log requests and their results.
-    #   Logging is done only to improve the services for future users. The logged data
-    #   is not shared or made public. If you are concerned with protecting the
-    #   privacy of users' personal information or otherwise do not want
-    #   your requests to be logged, you can opt out of logging.
     def initialize(args = {})
       @__async_initialized__ = false
       super()
@@ -87,7 +81,6 @@ module IBMWatson
       defaults[:iam_apikey] = nil
       defaults[:iam_access_token] = nil
       defaults[:iam_url] = nil
-      defaults[:x_watson_learning_opt_out] = false
       args = defaults.merge(args)
       @watson_service = WatsonService.new(
         vcap_services_name: "language_translator",
@@ -97,7 +90,6 @@ module IBMWatson
         iam_apikey: args[:iam_apikey],
         iam_access_token: args[:iam_access_token],
         iam_url: args[:iam_url],
-        x_watson_learning_opt_out: args[:x_watson_learning_opt_out],
         use_vcap_services: true
       )
       @version = args[:version]

--- a/lib/ibm_watson/language_translator_v3.rb
+++ b/lib/ibm_watson/language_translator_v3.rb
@@ -153,7 +153,7 @@ module IBMWatson
       @watson_service.url
     end
 
-    # @!method http_config(proxy: {}, timeout: {})
+    # @!method configure_http_client(proxy: {}, timeout: {})
     # Sets the http client config, currently works with timeout and proxies
     # @param proxy [Hash] The hash of proxy configurations
     # @option proxy address [String] The address of the proxy
@@ -164,8 +164,8 @@ module IBMWatson
     # @param timeout [Hash] The hash for configuring timeouts. `per_operation` has priority over `global`
     # @option timeout per_operation [Hash] Timeouts per operation. Requires `read`, `write`, `connect`
     # @option timeout global [Integer] Upper bound on total request time
-    def http_config(proxy: {}, timeout: {})
-      @watson_service.http_config(proxy: proxy, timeout: timeout)
+    def configure_http_client(proxy: {}, timeout: {})
+      @watson_service.configure_http_client(proxy: proxy, timeout: timeout)
     end
     # :nocov:
     #########################

--- a/lib/ibm_watson/language_translator_v3.rb
+++ b/lib/ibm_watson/language_translator_v3.rb
@@ -70,6 +70,12 @@ module IBMWatson
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
     #   'https://iam.ng.bluemix.net/identity/token'.
+    # @option args x_watson_learning_opt_out [Boolean] Set to `true` to opt-out of data collection.
+    #   By default, all IBM Watson services log requests and their results.
+    #   Logging is done only to improve the services for future users. The logged data
+    #   is not shared or made public. If you are concerned with protecting the
+    #   privacy of users' personal information or otherwise do not want
+    #   your requests to be logged, you can opt out of logging.
     def initialize(args = {})
       @__async_initialized__ = false
       super()
@@ -81,6 +87,7 @@ module IBMWatson
       defaults[:iam_apikey] = nil
       defaults[:iam_access_token] = nil
       defaults[:iam_url] = nil
+      defaults[:x_watson_learning_opt_out] = false
       args = defaults.merge(args)
       @watson_service = WatsonService.new(
         vcap_services_name: "language_translator",
@@ -90,6 +97,7 @@ module IBMWatson
         iam_apikey: args[:iam_apikey],
         iam_access_token: args[:iam_access_token],
         iam_url: args[:iam_url],
+        x_watson_learning_opt_out: args[:x_watson_learning_opt_out],
         use_vcap_services: true
       )
       @version = args[:version]
@@ -143,6 +151,21 @@ module IBMWatson
 
     def url
       @watson_service.url
+    end
+
+    # @!method http_config(proxy: {}, timeout: {})
+    # Sets the http client config, currently works with timeout and proxies
+    # @param proxy [Hash] The hash of proxy configurations
+    # @option proxy address [String] The address of the proxy
+    # @option proxy port [Integer] The port of the proxy
+    # @option proxy username [String] The username of the proxy, if authentication is needed
+    # @option proxy password [String] The password of the proxy, if authentication is needed
+    # @option proxy headers [Hash] The headers to be used with the proxy
+    # @param timeout [Hash] The hash for configuring timeouts. `per_operation` has priority over `global`
+    # @option timeout per_operation [Hash] Timeouts per operation. Requires `read`, `write`, `connect`
+    # @option timeout global [Integer] Upper bound on total request time
+    def http_config(proxy: {}, timeout: {})
+      @watson_service.http_config(proxy: proxy, timeout: timeout)
     end
     # :nocov:
     #########################

--- a/lib/ibm_watson/natural_language_classifier_v1.rb
+++ b/lib/ibm_watson/natural_language_classifier_v1.rb
@@ -140,7 +140,7 @@ module IBMWatson
       @watson_service.url
     end
 
-    # @!method http_config(proxy: {}, timeout: {})
+    # @!method configure_http_client(proxy: {}, timeout: {})
     # Sets the http client config, currently works with timeout and proxies
     # @param proxy [Hash] The hash of proxy configurations
     # @option proxy address [String] The address of the proxy
@@ -151,8 +151,8 @@ module IBMWatson
     # @param timeout [Hash] The hash for configuring timeouts. `per_operation` has priority over `global`
     # @option timeout per_operation [Hash] Timeouts per operation. Requires `read`, `write`, `connect`
     # @option timeout global [Integer] Upper bound on total request time
-    def http_config(proxy: {}, timeout: {})
-      @watson_service.http_config(proxy: proxy, timeout: timeout)
+    def configure_http_client(proxy: {}, timeout: {})
+      @watson_service.configure_http_client(proxy: proxy, timeout: timeout)
     end
     # :nocov:
     #########################

--- a/lib/ibm_watson/natural_language_classifier_v1.rb
+++ b/lib/ibm_watson/natural_language_classifier_v1.rb
@@ -59,6 +59,12 @@ module IBMWatson
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
     #   'https://iam.ng.bluemix.net/identity/token'.
+    # @option args x_watson_learning_opt_out [Boolean] Set to `true` to opt-out of data collection.
+    #   By default, all IBM Watson services log requests and their results.
+    #   Logging is done only to improve the services for future users. The logged data
+    #   is not shared or made public. If you are concerned with protecting the
+    #   privacy of users' personal information or otherwise do not want
+    #   your requests to be logged, you can opt out of logging.
     def initialize(args = {})
       @__async_initialized__ = false
       super()
@@ -69,6 +75,7 @@ module IBMWatson
       defaults[:iam_apikey] = nil
       defaults[:iam_access_token] = nil
       defaults[:iam_url] = nil
+      defaults[:x_watson_learning_opt_out] = false
       args = defaults.merge(args)
       @watson_service = WatsonService.new(
         vcap_services_name: "natural_language_classifier",
@@ -78,6 +85,7 @@ module IBMWatson
         iam_apikey: args[:iam_apikey],
         iam_access_token: args[:iam_access_token],
         iam_url: args[:iam_url],
+        x_watson_learning_opt_out: args[:x_watson_learning_opt_out],
         use_vcap_services: true
       )
     end
@@ -130,6 +138,21 @@ module IBMWatson
 
     def url
       @watson_service.url
+    end
+
+    # @!method http_config(proxy: {}, timeout: {})
+    # Sets the http client config, currently works with timeout and proxies
+    # @param proxy [Hash] The hash of proxy configurations
+    # @option proxy address [String] The address of the proxy
+    # @option proxy port [Integer] The port of the proxy
+    # @option proxy username [String] The username of the proxy, if authentication is needed
+    # @option proxy password [String] The password of the proxy, if authentication is needed
+    # @option proxy headers [Hash] The headers to be used with the proxy
+    # @param timeout [Hash] The hash for configuring timeouts. `per_operation` has priority over `global`
+    # @option timeout per_operation [Hash] Timeouts per operation. Requires `read`, `write`, `connect`
+    # @option timeout global [Integer] Upper bound on total request time
+    def http_config(proxy: {}, timeout: {})
+      @watson_service.http_config(proxy: proxy, timeout: timeout)
     end
     # :nocov:
     #########################

--- a/lib/ibm_watson/natural_language_classifier_v1.rb
+++ b/lib/ibm_watson/natural_language_classifier_v1.rb
@@ -59,12 +59,6 @@ module IBMWatson
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
     #   'https://iam.ng.bluemix.net/identity/token'.
-    # @option args x_watson_learning_opt_out [Boolean] Set to `true` to opt-out of data collection.
-    #   By default, all IBM Watson services log requests and their results.
-    #   Logging is done only to improve the services for future users. The logged data
-    #   is not shared or made public. If you are concerned with protecting the
-    #   privacy of users' personal information or otherwise do not want
-    #   your requests to be logged, you can opt out of logging.
     def initialize(args = {})
       @__async_initialized__ = false
       super()
@@ -75,7 +69,6 @@ module IBMWatson
       defaults[:iam_apikey] = nil
       defaults[:iam_access_token] = nil
       defaults[:iam_url] = nil
-      defaults[:x_watson_learning_opt_out] = false
       args = defaults.merge(args)
       @watson_service = WatsonService.new(
         vcap_services_name: "natural_language_classifier",
@@ -85,7 +78,6 @@ module IBMWatson
         iam_apikey: args[:iam_apikey],
         iam_access_token: args[:iam_access_token],
         iam_url: args[:iam_url],
-        x_watson_learning_opt_out: args[:x_watson_learning_opt_out],
         use_vcap_services: true
       )
     end

--- a/lib/ibm_watson/natural_language_understanding_v1.rb
+++ b/lib/ibm_watson/natural_language_understanding_v1.rb
@@ -157,7 +157,7 @@ module IBMWatson
       @watson_service.url
     end
 
-    # @!method http_config(proxy: {}, timeout: {})
+    # @!method configure_http_client(proxy: {}, timeout: {})
     # Sets the http client config, currently works with timeout and proxies
     # @param proxy [Hash] The hash of proxy configurations
     # @option proxy address [String] The address of the proxy
@@ -168,8 +168,8 @@ module IBMWatson
     # @param timeout [Hash] The hash for configuring timeouts. `per_operation` has priority over `global`
     # @option timeout per_operation [Hash] Timeouts per operation. Requires `read`, `write`, `connect`
     # @option timeout global [Integer] Upper bound on total request time
-    def http_config(proxy: {}, timeout: {})
-      @watson_service.http_config(proxy: proxy, timeout: timeout)
+    def configure_http_client(proxy: {}, timeout: {})
+      @watson_service.configure_http_client(proxy: proxy, timeout: timeout)
     end
     # :nocov:
     #########################

--- a/lib/ibm_watson/natural_language_understanding_v1.rb
+++ b/lib/ibm_watson/natural_language_understanding_v1.rb
@@ -74,12 +74,6 @@ module IBMWatson
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
     #   'https://iam.ng.bluemix.net/identity/token'.
-    # @option args x_watson_learning_opt_out [Boolean] Set to `true` to opt-out of data collection.
-    #   By default, all IBM Watson services log requests and their results.
-    #   Logging is done only to improve the services for future users. The logged data
-    #   is not shared or made public. If you are concerned with protecting the
-    #   privacy of users' personal information or otherwise do not want
-    #   your requests to be logged, you can opt out of logging.
     def initialize(args = {})
       @__async_initialized__ = false
       super()
@@ -91,7 +85,6 @@ module IBMWatson
       defaults[:iam_apikey] = nil
       defaults[:iam_access_token] = nil
       defaults[:iam_url] = nil
-      defaults[:x_watson_learning_opt_out] = false
       args = defaults.merge(args)
       @watson_service = WatsonService.new(
         vcap_services_name: "natural-language-understanding",
@@ -101,7 +94,6 @@ module IBMWatson
         iam_apikey: args[:iam_apikey],
         iam_access_token: args[:iam_access_token],
         iam_url: args[:iam_url],
-        x_watson_learning_opt_out: args[:x_watson_learning_opt_out],
         use_vcap_services: true
       )
       @version = args[:version]

--- a/lib/ibm_watson/natural_language_understanding_v1.rb
+++ b/lib/ibm_watson/natural_language_understanding_v1.rb
@@ -74,6 +74,12 @@ module IBMWatson
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
     #   'https://iam.ng.bluemix.net/identity/token'.
+    # @option args x_watson_learning_opt_out [Boolean] Set to `true` to opt-out of data collection.
+    #   By default, all IBM Watson services log requests and their results.
+    #   Logging is done only to improve the services for future users. The logged data
+    #   is not shared or made public. If you are concerned with protecting the
+    #   privacy of users' personal information or otherwise do not want
+    #   your requests to be logged, you can opt out of logging.
     def initialize(args = {})
       @__async_initialized__ = false
       super()
@@ -85,6 +91,7 @@ module IBMWatson
       defaults[:iam_apikey] = nil
       defaults[:iam_access_token] = nil
       defaults[:iam_url] = nil
+      defaults[:x_watson_learning_opt_out] = false
       args = defaults.merge(args)
       @watson_service = WatsonService.new(
         vcap_services_name: "natural-language-understanding",
@@ -94,6 +101,7 @@ module IBMWatson
         iam_apikey: args[:iam_apikey],
         iam_access_token: args[:iam_access_token],
         iam_url: args[:iam_url],
+        x_watson_learning_opt_out: args[:x_watson_learning_opt_out],
         use_vcap_services: true
       )
       @version = args[:version]
@@ -147,6 +155,21 @@ module IBMWatson
 
     def url
       @watson_service.url
+    end
+
+    # @!method http_config(proxy: {}, timeout: {})
+    # Sets the http client config, currently works with timeout and proxies
+    # @param proxy [Hash] The hash of proxy configurations
+    # @option proxy address [String] The address of the proxy
+    # @option proxy port [Integer] The port of the proxy
+    # @option proxy username [String] The username of the proxy, if authentication is needed
+    # @option proxy password [String] The password of the proxy, if authentication is needed
+    # @option proxy headers [Hash] The headers to be used with the proxy
+    # @param timeout [Hash] The hash for configuring timeouts. `per_operation` has priority over `global`
+    # @option timeout per_operation [Hash] Timeouts per operation. Requires `read`, `write`, `connect`
+    # @option timeout global [Integer] Upper bound on total request time
+    def http_config(proxy: {}, timeout: {})
+      @watson_service.http_config(proxy: proxy, timeout: timeout)
     end
     # :nocov:
     #########################

--- a/lib/ibm_watson/personality_insights_v3.rb
+++ b/lib/ibm_watson/personality_insights_v3.rb
@@ -85,6 +85,12 @@ module IBMWatson
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
     #   'https://iam.ng.bluemix.net/identity/token'.
+    # @option args x_watson_learning_opt_out [Boolean] Set to `true` to opt-out of data collection.
+    #   By default, all IBM Watson services log requests and their results.
+    #   Logging is done only to improve the services for future users. The logged data
+    #   is not shared or made public. If you are concerned with protecting the
+    #   privacy of users' personal information or otherwise do not want
+    #   your requests to be logged, you can opt out of logging.
     def initialize(args = {})
       @__async_initialized__ = false
       super()
@@ -96,6 +102,7 @@ module IBMWatson
       defaults[:iam_apikey] = nil
       defaults[:iam_access_token] = nil
       defaults[:iam_url] = nil
+      defaults[:x_watson_learning_opt_out] = false
       args = defaults.merge(args)
       @watson_service = WatsonService.new(
         vcap_services_name: "personality_insights",
@@ -105,6 +112,7 @@ module IBMWatson
         iam_apikey: args[:iam_apikey],
         iam_access_token: args[:iam_access_token],
         iam_url: args[:iam_url],
+        x_watson_learning_opt_out: args[:x_watson_learning_opt_out],
         use_vcap_services: true
       )
       @version = args[:version]
@@ -158,6 +166,21 @@ module IBMWatson
 
     def url
       @watson_service.url
+    end
+
+    # @!method http_config(proxy: {}, timeout: {})
+    # Sets the http client config, currently works with timeout and proxies
+    # @param proxy [Hash] The hash of proxy configurations
+    # @option proxy address [String] The address of the proxy
+    # @option proxy port [Integer] The port of the proxy
+    # @option proxy username [String] The username of the proxy, if authentication is needed
+    # @option proxy password [String] The password of the proxy, if authentication is needed
+    # @option proxy headers [Hash] The headers to be used with the proxy
+    # @param timeout [Hash] The hash for configuring timeouts. `per_operation` has priority over `global`
+    # @option timeout per_operation [Hash] Timeouts per operation. Requires `read`, `write`, `connect`
+    # @option timeout global [Integer] Upper bound on total request time
+    def http_config(proxy: {}, timeout: {})
+      @watson_service.http_config(proxy: proxy, timeout: timeout)
     end
     # :nocov:
     #########################

--- a/lib/ibm_watson/personality_insights_v3.rb
+++ b/lib/ibm_watson/personality_insights_v3.rb
@@ -85,12 +85,6 @@ module IBMWatson
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
     #   'https://iam.ng.bluemix.net/identity/token'.
-    # @option args x_watson_learning_opt_out [Boolean] Set to `true` to opt-out of data collection.
-    #   By default, all IBM Watson services log requests and their results.
-    #   Logging is done only to improve the services for future users. The logged data
-    #   is not shared or made public. If you are concerned with protecting the
-    #   privacy of users' personal information or otherwise do not want
-    #   your requests to be logged, you can opt out of logging.
     def initialize(args = {})
       @__async_initialized__ = false
       super()
@@ -102,7 +96,6 @@ module IBMWatson
       defaults[:iam_apikey] = nil
       defaults[:iam_access_token] = nil
       defaults[:iam_url] = nil
-      defaults[:x_watson_learning_opt_out] = false
       args = defaults.merge(args)
       @watson_service = WatsonService.new(
         vcap_services_name: "personality_insights",
@@ -112,7 +105,6 @@ module IBMWatson
         iam_apikey: args[:iam_apikey],
         iam_access_token: args[:iam_access_token],
         iam_url: args[:iam_url],
-        x_watson_learning_opt_out: args[:x_watson_learning_opt_out],
         use_vcap_services: true
       )
       @version = args[:version]

--- a/lib/ibm_watson/personality_insights_v3.rb
+++ b/lib/ibm_watson/personality_insights_v3.rb
@@ -168,7 +168,7 @@ module IBMWatson
       @watson_service.url
     end
 
-    # @!method http_config(proxy: {}, timeout: {})
+    # @!method configure_http_client(proxy: {}, timeout: {})
     # Sets the http client config, currently works with timeout and proxies
     # @param proxy [Hash] The hash of proxy configurations
     # @option proxy address [String] The address of the proxy
@@ -179,8 +179,8 @@ module IBMWatson
     # @param timeout [Hash] The hash for configuring timeouts. `per_operation` has priority over `global`
     # @option timeout per_operation [Hash] Timeouts per operation. Requires `read`, `write`, `connect`
     # @option timeout global [Integer] Upper bound on total request time
-    def http_config(proxy: {}, timeout: {})
-      @watson_service.http_config(proxy: proxy, timeout: timeout)
+    def configure_http_client(proxy: {}, timeout: {})
+      @watson_service.configure_http_client(proxy: proxy, timeout: timeout)
     end
     # :nocov:
     #########################

--- a/lib/ibm_watson/speech_to_text_v1.rb
+++ b/lib/ibm_watson/speech_to_text_v1.rb
@@ -107,12 +107,6 @@ module IBMWatson
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
     #   'https://iam.ng.bluemix.net/identity/token'.
-    # @option args x_watson_learning_opt_out [Boolean] Set to `true` to opt-out of data collection.
-    #   By default, all IBM Watson services log requests and their results.
-    #   Logging is done only to improve the services for future users. The logged data
-    #   is not shared or made public. If you are concerned with protecting the
-    #   privacy of users' personal information or otherwise do not want
-    #   your requests to be logged, you can opt out of logging.
     def initialize(args = {})
       @__async_initialized__ = false
       super()
@@ -123,7 +117,6 @@ module IBMWatson
       defaults[:iam_apikey] = nil
       defaults[:iam_access_token] = nil
       defaults[:iam_url] = nil
-      defaults[:x_watson_learning_opt_out] = false
       args = defaults.merge(args)
       @watson_service = WatsonService.new(
         vcap_services_name: "speech_to_text",
@@ -133,7 +126,6 @@ module IBMWatson
         iam_apikey: args[:iam_apikey],
         iam_access_token: args[:iam_access_token],
         iam_url: args[:iam_url],
-        x_watson_learning_opt_out: args[:x_watson_learning_opt_out],
         use_vcap_services: true
       )
     end

--- a/lib/ibm_watson/speech_to_text_v1.rb
+++ b/lib/ibm_watson/speech_to_text_v1.rb
@@ -188,7 +188,7 @@ module IBMWatson
       @watson_service.url
     end
 
-    # @!method http_config(proxy: {}, timeout: {})
+    # @!method configure_http_client(proxy: {}, timeout: {})
     # Sets the http client config, currently works with timeout and proxies
     # @param proxy [Hash] The hash of proxy configurations
     # @option proxy address [String] The address of the proxy
@@ -199,8 +199,8 @@ module IBMWatson
     # @param timeout [Hash] The hash for configuring timeouts. `per_operation` has priority over `global`
     # @option timeout per_operation [Hash] Timeouts per operation. Requires `read`, `write`, `connect`
     # @option timeout global [Integer] Upper bound on total request time
-    def http_config(proxy: {}, timeout: {})
-      @watson_service.http_config(proxy: proxy, timeout: timeout)
+    def configure_http_client(proxy: {}, timeout: {})
+      @watson_service.configure_http_client(proxy: proxy, timeout: timeout)
     end
     # :nocov:
     #########################

--- a/lib/ibm_watson/speech_to_text_v1.rb
+++ b/lib/ibm_watson/speech_to_text_v1.rb
@@ -107,6 +107,12 @@ module IBMWatson
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
     #   'https://iam.ng.bluemix.net/identity/token'.
+    # @option args x_watson_learning_opt_out [Boolean] Set to `true` to opt-out of data collection.
+    #   By default, all IBM Watson services log requests and their results.
+    #   Logging is done only to improve the services for future users. The logged data
+    #   is not shared or made public. If you are concerned with protecting the
+    #   privacy of users' personal information or otherwise do not want
+    #   your requests to be logged, you can opt out of logging.
     def initialize(args = {})
       @__async_initialized__ = false
       super()
@@ -117,6 +123,7 @@ module IBMWatson
       defaults[:iam_apikey] = nil
       defaults[:iam_access_token] = nil
       defaults[:iam_url] = nil
+      defaults[:x_watson_learning_opt_out] = false
       args = defaults.merge(args)
       @watson_service = WatsonService.new(
         vcap_services_name: "speech_to_text",
@@ -126,6 +133,7 @@ module IBMWatson
         iam_apikey: args[:iam_apikey],
         iam_access_token: args[:iam_access_token],
         iam_url: args[:iam_url],
+        x_watson_learning_opt_out: args[:x_watson_learning_opt_out],
         use_vcap_services: true
       )
     end
@@ -178,6 +186,21 @@ module IBMWatson
 
     def url
       @watson_service.url
+    end
+
+    # @!method http_config(proxy: {}, timeout: {})
+    # Sets the http client config, currently works with timeout and proxies
+    # @param proxy [Hash] The hash of proxy configurations
+    # @option proxy address [String] The address of the proxy
+    # @option proxy port [Integer] The port of the proxy
+    # @option proxy username [String] The username of the proxy, if authentication is needed
+    # @option proxy password [String] The password of the proxy, if authentication is needed
+    # @option proxy headers [Hash] The headers to be used with the proxy
+    # @param timeout [Hash] The hash for configuring timeouts. `per_operation` has priority over `global`
+    # @option timeout per_operation [Hash] Timeouts per operation. Requires `read`, `write`, `connect`
+    # @option timeout global [Integer] Upper bound on total request time
+    def http_config(proxy: {}, timeout: {})
+      @watson_service.http_config(proxy: proxy, timeout: timeout)
     end
     # :nocov:
     #########################

--- a/lib/ibm_watson/text_to_speech_v1.rb
+++ b/lib/ibm_watson/text_to_speech_v1.rb
@@ -189,7 +189,7 @@ module IBMWatson
       @watson_service.url
     end
 
-    # @!method http_config(proxy: {}, timeout: {})
+    # @!method configure_http_client(proxy: {}, timeout: {})
     # Sets the http client config, currently works with timeout and proxies
     # @param proxy [Hash] The hash of proxy configurations
     # @option proxy address [String] The address of the proxy
@@ -200,8 +200,8 @@ module IBMWatson
     # @param timeout [Hash] The hash for configuring timeouts. `per_operation` has priority over `global`
     # @option timeout per_operation [Hash] Timeouts per operation. Requires `read`, `write`, `connect`
     # @option timeout global [Integer] Upper bound on total request time
-    def http_config(proxy: {}, timeout: {})
-      @watson_service.http_config(proxy: proxy, timeout: timeout)
+    def configure_http_client(proxy: {}, timeout: {})
+      @watson_service.configure_http_client(proxy: proxy, timeout: timeout)
     end
     # :nocov:
     #########################

--- a/lib/ibm_watson/text_to_speech_v1.rb
+++ b/lib/ibm_watson/text_to_speech_v1.rb
@@ -108,6 +108,12 @@ module IBMWatson
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
     #   'https://iam.ng.bluemix.net/identity/token'.
+    # @option args x_watson_learning_opt_out [Boolean] Set to `true` to opt-out of data collection.
+    #   By default, all IBM Watson services log requests and their results.
+    #   Logging is done only to improve the services for future users. The logged data
+    #   is not shared or made public. If you are concerned with protecting the
+    #   privacy of users' personal information or otherwise do not want
+    #   your requests to be logged, you can opt out of logging.
     def initialize(args = {})
       @__async_initialized__ = false
       super()
@@ -118,6 +124,7 @@ module IBMWatson
       defaults[:iam_apikey] = nil
       defaults[:iam_access_token] = nil
       defaults[:iam_url] = nil
+      defaults[:x_watson_learning_opt_out] = false
       args = defaults.merge(args)
       @watson_service = WatsonService.new(
         vcap_services_name: "text_to_speech",
@@ -127,6 +134,7 @@ module IBMWatson
         iam_apikey: args[:iam_apikey],
         iam_access_token: args[:iam_access_token],
         iam_url: args[:iam_url],
+        x_watson_learning_opt_out: args[:x_watson_learning_opt_out],
         use_vcap_services: true
       )
     end
@@ -179,6 +187,21 @@ module IBMWatson
 
     def url
       @watson_service.url
+    end
+
+    # @!method http_config(proxy: {}, timeout: {})
+    # Sets the http client config, currently works with timeout and proxies
+    # @param proxy [Hash] The hash of proxy configurations
+    # @option proxy address [String] The address of the proxy
+    # @option proxy port [Integer] The port of the proxy
+    # @option proxy username [String] The username of the proxy, if authentication is needed
+    # @option proxy password [String] The password of the proxy, if authentication is needed
+    # @option proxy headers [Hash] The headers to be used with the proxy
+    # @param timeout [Hash] The hash for configuring timeouts. `per_operation` has priority over `global`
+    # @option timeout per_operation [Hash] Timeouts per operation. Requires `read`, `write`, `connect`
+    # @option timeout global [Integer] Upper bound on total request time
+    def http_config(proxy: {}, timeout: {})
+      @watson_service.http_config(proxy: proxy, timeout: timeout)
     end
     # :nocov:
     #########################

--- a/lib/ibm_watson/text_to_speech_v1.rb
+++ b/lib/ibm_watson/text_to_speech_v1.rb
@@ -108,12 +108,6 @@ module IBMWatson
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
     #   'https://iam.ng.bluemix.net/identity/token'.
-    # @option args x_watson_learning_opt_out [Boolean] Set to `true` to opt-out of data collection.
-    #   By default, all IBM Watson services log requests and their results.
-    #   Logging is done only to improve the services for future users. The logged data
-    #   is not shared or made public. If you are concerned with protecting the
-    #   privacy of users' personal information or otherwise do not want
-    #   your requests to be logged, you can opt out of logging.
     def initialize(args = {})
       @__async_initialized__ = false
       super()
@@ -124,7 +118,6 @@ module IBMWatson
       defaults[:iam_apikey] = nil
       defaults[:iam_access_token] = nil
       defaults[:iam_url] = nil
-      defaults[:x_watson_learning_opt_out] = false
       args = defaults.merge(args)
       @watson_service = WatsonService.new(
         vcap_services_name: "text_to_speech",
@@ -134,7 +127,6 @@ module IBMWatson
         iam_apikey: args[:iam_apikey],
         iam_access_token: args[:iam_access_token],
         iam_url: args[:iam_url],
-        x_watson_learning_opt_out: args[:x_watson_learning_opt_out],
         use_vcap_services: true
       )
     end

--- a/lib/ibm_watson/tone_analyzer_v3.rb
+++ b/lib/ibm_watson/tone_analyzer_v3.rb
@@ -76,12 +76,6 @@ module IBMWatson
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
     #   'https://iam.ng.bluemix.net/identity/token'.
-    # @option args x_watson_learning_opt_out [Boolean] Set to `true` to opt-out of data collection.
-    #   By default, all IBM Watson services log requests and their results.
-    #   Logging is done only to improve the services for future users. The logged data
-    #   is not shared or made public. If you are concerned with protecting the
-    #   privacy of users' personal information or otherwise do not want
-    #   your requests to be logged, you can opt out of logging.
     def initialize(args = {})
       @__async_initialized__ = false
       super()
@@ -93,7 +87,6 @@ module IBMWatson
       defaults[:iam_apikey] = nil
       defaults[:iam_access_token] = nil
       defaults[:iam_url] = nil
-      defaults[:x_watson_learning_opt_out] = false
       args = defaults.merge(args)
       @watson_service = WatsonService.new(
         vcap_services_name: "tone_analyzer",
@@ -103,7 +96,6 @@ module IBMWatson
         iam_apikey: args[:iam_apikey],
         iam_access_token: args[:iam_access_token],
         iam_url: args[:iam_url],
-        x_watson_learning_opt_out: args[:x_watson_learning_opt_out],
         use_vcap_services: true
       )
       @version = args[:version]

--- a/lib/ibm_watson/tone_analyzer_v3.rb
+++ b/lib/ibm_watson/tone_analyzer_v3.rb
@@ -76,6 +76,12 @@ module IBMWatson
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
     #   'https://iam.ng.bluemix.net/identity/token'.
+    # @option args x_watson_learning_opt_out [Boolean] Set to `true` to opt-out of data collection.
+    #   By default, all IBM Watson services log requests and their results.
+    #   Logging is done only to improve the services for future users. The logged data
+    #   is not shared or made public. If you are concerned with protecting the
+    #   privacy of users' personal information or otherwise do not want
+    #   your requests to be logged, you can opt out of logging.
     def initialize(args = {})
       @__async_initialized__ = false
       super()
@@ -87,6 +93,7 @@ module IBMWatson
       defaults[:iam_apikey] = nil
       defaults[:iam_access_token] = nil
       defaults[:iam_url] = nil
+      defaults[:x_watson_learning_opt_out] = false
       args = defaults.merge(args)
       @watson_service = WatsonService.new(
         vcap_services_name: "tone_analyzer",
@@ -96,6 +103,7 @@ module IBMWatson
         iam_apikey: args[:iam_apikey],
         iam_access_token: args[:iam_access_token],
         iam_url: args[:iam_url],
+        x_watson_learning_opt_out: args[:x_watson_learning_opt_out],
         use_vcap_services: true
       )
       @version = args[:version]
@@ -149,6 +157,21 @@ module IBMWatson
 
     def url
       @watson_service.url
+    end
+
+    # @!method http_config(proxy: {}, timeout: {})
+    # Sets the http client config, currently works with timeout and proxies
+    # @param proxy [Hash] The hash of proxy configurations
+    # @option proxy address [String] The address of the proxy
+    # @option proxy port [Integer] The port of the proxy
+    # @option proxy username [String] The username of the proxy, if authentication is needed
+    # @option proxy password [String] The password of the proxy, if authentication is needed
+    # @option proxy headers [Hash] The headers to be used with the proxy
+    # @param timeout [Hash] The hash for configuring timeouts. `per_operation` has priority over `global`
+    # @option timeout per_operation [Hash] Timeouts per operation. Requires `read`, `write`, `connect`
+    # @option timeout global [Integer] Upper bound on total request time
+    def http_config(proxy: {}, timeout: {})
+      @watson_service.http_config(proxy: proxy, timeout: timeout)
     end
     # :nocov:
     #########################

--- a/lib/ibm_watson/tone_analyzer_v3.rb
+++ b/lib/ibm_watson/tone_analyzer_v3.rb
@@ -159,7 +159,7 @@ module IBMWatson
       @watson_service.url
     end
 
-    # @!method http_config(proxy: {}, timeout: {})
+    # @!method configure_http_client(proxy: {}, timeout: {})
     # Sets the http client config, currently works with timeout and proxies
     # @param proxy [Hash] The hash of proxy configurations
     # @option proxy address [String] The address of the proxy
@@ -170,8 +170,8 @@ module IBMWatson
     # @param timeout [Hash] The hash for configuring timeouts. `per_operation` has priority over `global`
     # @option timeout per_operation [Hash] Timeouts per operation. Requires `read`, `write`, `connect`
     # @option timeout global [Integer] Upper bound on total request time
-    def http_config(proxy: {}, timeout: {})
-      @watson_service.http_config(proxy: proxy, timeout: timeout)
+    def configure_http_client(proxy: {}, timeout: {})
+      @watson_service.configure_http_client(proxy: proxy, timeout: timeout)
     end
     # :nocov:
     #########################

--- a/lib/ibm_watson/visual_recognition_v3.rb
+++ b/lib/ibm_watson/visual_recognition_v3.rb
@@ -140,7 +140,7 @@ module IBMWatson
       @watson_service.url
     end
 
-    # @!method http_config(proxy: {}, timeout: {})
+    # @!method configure_http_client(proxy: {}, timeout: {})
     # Sets the http client config, currently works with timeout and proxies
     # @param proxy [Hash] The hash of proxy configurations
     # @option proxy address [String] The address of the proxy
@@ -151,8 +151,8 @@ module IBMWatson
     # @param timeout [Hash] The hash for configuring timeouts. `per_operation` has priority over `global`
     # @option timeout per_operation [Hash] Timeouts per operation. Requires `read`, `write`, `connect`
     # @option timeout global [Integer] Upper bound on total request time
-    def http_config(proxy: {}, timeout: {})
-      @watson_service.http_config(proxy: proxy, timeout: timeout)
+    def configure_http_client(proxy: {}, timeout: {})
+      @watson_service.configure_http_client(proxy: proxy, timeout: timeout)
     end
     # :nocov:
     #########################

--- a/lib/ibm_watson/visual_recognition_v3.rb
+++ b/lib/ibm_watson/visual_recognition_v3.rb
@@ -59,12 +59,6 @@ module IBMWatson
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
     #   'https://iam.ng.bluemix.net/identity/token'.
-    # @option args x_watson_learning_opt_out [Boolean] Set to `true` to opt-out of data collection.
-    #   By default, all IBM Watson services log requests and their results.
-    #   Logging is done only to improve the services for future users. The logged data
-    #   is not shared or made public. If you are concerned with protecting the
-    #   privacy of users' personal information or otherwise do not want
-    #   your requests to be logged, you can opt out of logging.
     def initialize(args = {})
       @__async_initialized__ = false
       super()
@@ -75,7 +69,6 @@ module IBMWatson
       defaults[:iam_apikey] = nil
       defaults[:iam_access_token] = nil
       defaults[:iam_url] = nil
-      defaults[:x_watson_learning_opt_out] = false
       args = defaults.merge(args)
       @watson_service = WatsonService.new(
         vcap_services_name: "watson_vision_combined",
@@ -84,7 +77,6 @@ module IBMWatson
         iam_apikey: args[:iam_apikey],
         iam_access_token: args[:iam_access_token],
         iam_url: args[:iam_url],
-        x_watson_learning_opt_out: args[:x_watson_learning_opt_out],
         use_vcap_services: true
       )
       @version = args[:version]

--- a/lib/ibm_watson/visual_recognition_v3.rb
+++ b/lib/ibm_watson/visual_recognition_v3.rb
@@ -59,6 +59,12 @@ module IBMWatson
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
     #   'https://iam.ng.bluemix.net/identity/token'.
+    # @option args x_watson_learning_opt_out [Boolean] Set to `true` to opt-out of data collection.
+    #   By default, all IBM Watson services log requests and their results.
+    #   Logging is done only to improve the services for future users. The logged data
+    #   is not shared or made public. If you are concerned with protecting the
+    #   privacy of users' personal information or otherwise do not want
+    #   your requests to be logged, you can opt out of logging.
     def initialize(args = {})
       @__async_initialized__ = false
       super()
@@ -69,6 +75,7 @@ module IBMWatson
       defaults[:iam_apikey] = nil
       defaults[:iam_access_token] = nil
       defaults[:iam_url] = nil
+      defaults[:x_watson_learning_opt_out] = false
       args = defaults.merge(args)
       @watson_service = WatsonService.new(
         vcap_services_name: "watson_vision_combined",
@@ -77,6 +84,7 @@ module IBMWatson
         iam_apikey: args[:iam_apikey],
         iam_access_token: args[:iam_access_token],
         iam_url: args[:iam_url],
+        x_watson_learning_opt_out: args[:x_watson_learning_opt_out],
         use_vcap_services: true
       )
       @version = args[:version]
@@ -130,6 +138,21 @@ module IBMWatson
 
     def url
       @watson_service.url
+    end
+
+    # @!method http_config(proxy: {}, timeout: {})
+    # Sets the http client config, currently works with timeout and proxies
+    # @param proxy [Hash] The hash of proxy configurations
+    # @option proxy address [String] The address of the proxy
+    # @option proxy port [Integer] The port of the proxy
+    # @option proxy username [String] The username of the proxy, if authentication is needed
+    # @option proxy password [String] The password of the proxy, if authentication is needed
+    # @option proxy headers [Hash] The headers to be used with the proxy
+    # @param timeout [Hash] The hash for configuring timeouts. `per_operation` has priority over `global`
+    # @option timeout per_operation [Hash] Timeouts per operation. Requires `read`, `write`, `connect`
+    # @option timeout global [Integer] Upper bound on total request time
+    def http_config(proxy: {}, timeout: {})
+      @watson_service.http_config(proxy: proxy, timeout: timeout)
     end
     # :nocov:
     #########################

--- a/lib/ibm_watson/watson_service.rb
+++ b/lib/ibm_watson/watson_service.rb
@@ -173,7 +173,7 @@ class WatsonService
     self
   end
 
-  # @!method http_config(proxy: {}, timeout: {})
+  # @!method configure_http_client(proxy: {}, timeout: {})
   # Sets the http client config, currently works with timeout and proxies
   # @param proxy [Hash] The hash of proxy configurations
   # @option proxy address [String] The address of the proxy
@@ -184,7 +184,7 @@ class WatsonService
   # @param timeout [Hash] The hash for configuring timeouts. `per_operation` has priority over `global`
   # @option timeout per_operation [Hash] Timeouts per operation. Requires `read`, `write`, `connect`
   # @option timeout global [Integer] Upper bound on total request time
-  def http_config(proxy: {}, timeout: {})
+  def configure_http_client(proxy: {}, timeout: {})
     raise TypeError("proxy parameter must be a Hash") unless proxy.empty? || proxy.instance_of?(Hash)
     raise TypeError("timeout parameter must be a Hash") unless timeout.empty? || timeout.instance_of?(Hash)
     add_proxy(proxy) unless proxy.empty? || !proxy.dig(:address).is_a?(String) || !proxy.dig(:port).is_a?(Integer)

--- a/lib/ibm_watson/watson_service.rb
+++ b/lib/ibm_watson/watson_service.rb
@@ -74,11 +74,6 @@ class WatsonService
 
     @conn = HTTP::Client.new(
       headers: headers
-    ).timeout(
-      :per_operation,
-      read: 60,
-      write: 60,
-      connect: 60
     )
   end
 
@@ -176,5 +171,53 @@ class WatsonService
     raise TypeError("Expected Hash type, received #{headers.class}") unless headers.instance_of?(Hash)
     @temp_headers = headers
     self
+  end
+
+  # @!method http_config(proxy: {}, timeout: {})
+  # Sets the http client config, currently works with timeout and proxies
+  # @param proxy [Hash] The hash of proxy configurations
+  # @option proxy address [String] The address of the proxy
+  # @option proxy port [Integer] The port of the proxy
+  # @option proxy username [String] The username of the proxy, if authentication is needed
+  # @option proxy password [String] The password of the proxy, if authentication is needed
+  # @option proxy headers [Hash] The headers to be used with the proxy
+  # @param timeout [Hash] The hash for configuring timeouts. `per_operation` has priority over `global`
+  # @option timeout per_operation [Hash] Timeouts per operation. Requires `read`, `write`, `connect`
+  # @option timeout global [Integer] Upper bound on total request time
+  def http_config(proxy: {}, timeout: {})
+    raise TypeError("proxy parameter must be a Hash") unless proxy.empty? || proxy.instance_of?(Hash)
+    raise TypeError("timeout parameter must be a Hash") unless timeout.empty? || timeout.instance_of?(Hash)
+    add_proxy(proxy) unless proxy.empty? || !proxy.dig(:address).is_a?(String) || !proxy.dig(:port).is_a?(Integer)
+    add_timeout(timeout) unless timeout.empty? || (!timeout.key?(:per_operation) && !timeout.key?(:global))
+  end
+
+  private
+
+  def add_timeout(timeout)
+    if timeout.key?(:per_operation)
+      raise TypeError("per_operation in timeout must be a Hash") unless timeout[:per_operation].instance_of?(Hash)
+      defaults = {
+        write: 0,
+        connect: 0,
+        read: 0
+      }
+      time = defaults.merge(timeout[:per_operation])
+      @conn = @conn.timeout(:per_operation, write: time[:write], connect: time[:connect], read: time[:read])
+    else
+      raise TypeError("global in timeout must be an Integer") unless timeout[:global].is_a?(Integer)
+      @conn = @conn.timeout(:global, write: timeout[:global], connect: 0, read: 0)
+    end
+  end
+
+  def add_proxy(proxy)
+    if (proxy[:username].nil? || proxy[:password].nil?) && proxy[:headers].nil?
+      @conn = @conn.via(proxy[:address], proxy[:port])
+    elsif !proxy[:username].nil? && !proxy[:password].nil? && proxy[:headers].nil?
+      @conn = @conn.via(proxy[:address], proxy[:port], proxy[:username], proxy[:password])
+    elsif !proxy[:headers].nil? && (proxy[:username].nil? || proxy[:password].nil?)
+      @conn = @conn.via(proxy[:address], proxy[:port], proxy[:headers])
+    else
+      @conn = @conn.via(proxy[:address], proxy[:port], proxy[:username], proxy[:password], proxy[:headers])
+    end
   end
 end

--- a/lib/ibm_watson/watson_service.rb
+++ b/lib/ibm_watson/watson_service.rb
@@ -29,7 +29,6 @@ class WatsonService
       password: nil,
       use_vcap_services: true,
       api_key: nil,
-      x_watson_learning_opt_out: false,
       iam_apikey: nil,
       iam_access_token: nil,
       iam_url: nil
@@ -48,7 +47,6 @@ class WatsonService
     headers = {
       "User-Agent" => user_agent_string
     }
-    headers["x-watson-learning-opt-out"] = true if vars[:x_watson_learning_opt_out]
     if vars[:use_vcap_services]
       @vcap_service_credentials = load_from_vcap_services(service_name: vars[:vcap_services_name])
       if !@vcap_service_credentials.nil? && @vcap_service_credentials.instance_of?(Hash)

--- a/test/unit/test_configure_http_client.rb
+++ b/test/unit/test_configure_http_client.rb
@@ -6,7 +6,7 @@ require("webmock/minitest")
 
 WebMock.disable_net_connect!(allow_localhost: true)
 
-# Unit tests for the http_config customizations, such as proxies and timeouts
+# Unit tests for the configure_http_client customizations, such as proxies and timeouts
 class HTTPConfigTest < Minitest::Test
   def test_proxy_address_port
     service = IBMWatson::NaturalLanguageUnderstandingV1.new(
@@ -17,7 +17,7 @@ class HTTPConfigTest < Minitest::Test
     def service.conn
       @watson_service.conn
     end
-    service.http_config(
+    service.configure_http_client(
       proxy: {
         address: "bogus_address.com",
         port: 9999
@@ -37,7 +37,7 @@ class HTTPConfigTest < Minitest::Test
     def service.conn
       @watson_service.conn
     end
-    service.http_config(
+    service.configure_http_client(
       proxy: {
         address: "bogus_address.com",
         port: 9999,
@@ -61,7 +61,7 @@ class HTTPConfigTest < Minitest::Test
     def service.conn
       @watson_service.conn
     end
-    service.http_config(
+    service.configure_http_client(
       proxy: {
         address: "bogus_address.com",
         port: 9999,
@@ -85,7 +85,7 @@ class HTTPConfigTest < Minitest::Test
     def service.conn
       @watson_service.conn
     end
-    service.http_config(
+    service.configure_http_client(
       proxy: {
         address: "bogus_address.com",
         port: 9999,
@@ -113,7 +113,7 @@ class HTTPConfigTest < Minitest::Test
     def service.conn
       @watson_service.conn
     end
-    service.http_config(
+    service.configure_http_client(
       timeout: {
         per_operation: {
           read: 5,
@@ -143,7 +143,7 @@ class HTTPConfigTest < Minitest::Test
     def service.conn
       @watson_service.conn
     end
-    service.http_config(
+    service.configure_http_client(
       timeout: {
         global: 20
       }

--- a/test/unit/test_http_config.rb
+++ b/test/unit/test_http_config.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require("json")
+require_relative("./../test_helper.rb")
+require("webmock/minitest")
+
+WebMock.disable_net_connect!(allow_localhost: true)
+
+# Unit tests for the http_config customizations, such as proxies and timeouts
+class HTTPConfigTest < Minitest::Test
+  def test_proxy_address_port
+    service = IBMWatson::NaturalLanguageUnderstandingV1.new(
+      version: "2018-03-16",
+      username: "username",
+      password: "password"
+    )
+    def service.conn
+      @watson_service.conn
+    end
+    service.http_config(
+      proxy: {
+        address: "bogus_address.com",
+        port: 9999
+      }
+    )
+    proxy = service.conn.default_options.proxy
+    assert_equal("bogus_address.com", proxy[:proxy_address])
+    assert_equal(9999, proxy[:proxy_port])
+  end
+
+  def test_proxy_username_password
+    service = IBMWatson::NaturalLanguageUnderstandingV1.new(
+      version: "2018-03-16",
+      username: "username",
+      password: "password"
+    )
+    def service.conn
+      @watson_service.conn
+    end
+    service.http_config(
+      proxy: {
+        address: "bogus_address.com",
+        port: 9999,
+        username: "username",
+        password: "password"
+      }
+    )
+    proxy = service.conn.default_options.proxy
+    assert_equal("bogus_address.com", proxy[:proxy_address])
+    assert_equal(9999, proxy[:proxy_port])
+    assert_equal("username", proxy[:proxy_username])
+    assert_equal("password", proxy[:proxy_password])
+  end
+
+  def test_proxy_headers
+    service = IBMWatson::NaturalLanguageUnderstandingV1.new(
+      version: "2018-03-16",
+      username: "username",
+      password: "password"
+    )
+    def service.conn
+      @watson_service.conn
+    end
+    service.http_config(
+      proxy: {
+        address: "bogus_address.com",
+        port: 9999,
+        headers: {
+          bogus_header: true
+        }
+      }
+    )
+    proxy = service.conn.default_options.proxy
+    assert_equal("bogus_address.com", proxy[:proxy_address])
+    assert_equal(9999, proxy[:proxy_port])
+    assert_equal({ bogus_header: true }, proxy[:proxy_headers])
+  end
+
+  def test_proxy_username_password_headers
+    service = IBMWatson::NaturalLanguageUnderstandingV1.new(
+      version: "2018-03-16",
+      username: "username",
+      password: "password"
+    )
+    def service.conn
+      @watson_service.conn
+    end
+    service.http_config(
+      proxy: {
+        address: "bogus_address.com",
+        port: 9999,
+        username: "username",
+        password: "password",
+        headers: {
+          bogus_header: true
+        }
+      }
+    )
+    proxy = service.conn.default_options.proxy
+    assert_equal("bogus_address.com", proxy[:proxy_address])
+    assert_equal(9999, proxy[:proxy_port])
+    assert_equal("username", proxy[:proxy_username])
+    assert_equal("password", proxy[:proxy_password])
+    assert_equal({ bogus_header: true }, proxy[:proxy_headers])
+  end
+
+  def test_timeout_per_operation
+    service = IBMWatson::NaturalLanguageUnderstandingV1.new(
+      version: "2018-03-16",
+      username: "username",
+      password: "password"
+    )
+    def service.conn
+      @watson_service.conn
+    end
+    service.http_config(
+      timeout: {
+        per_operation: {
+          read: 5,
+          write: 7,
+          connect: 10
+        }
+      }
+    )
+    timeout_class = service.conn.default_options.timeout_class
+    assert_equal(HTTP::Timeout::PerOperation, timeout_class)
+
+    expected_timeouts = {
+      read_timeout: 5,
+      write_timeout: 7,
+      connect_timeout: 10
+    }
+    timeout = service.conn.default_options.timeout_options
+    assert_equal(expected_timeouts, timeout)
+  end
+
+  def test_timeout_global
+    service = IBMWatson::NaturalLanguageUnderstandingV1.new(
+      version: "2018-03-16",
+      username: "username",
+      password: "password"
+    )
+    def service.conn
+      @watson_service.conn
+    end
+    service.http_config(
+      timeout: {
+        global: 20
+      }
+    )
+    timeout_class = service.conn.default_options.timeout_class
+    assert_equal(HTTP::Timeout::Global, timeout_class)
+
+    expected_timeouts = {
+      read_timeout: 0,
+      write_timeout: 20,
+      connect_timeout: 0
+    }
+    timeout = service.conn.default_options.timeout_options
+    assert_equal(expected_timeouts, timeout)
+  end
+end


### PR DESCRIPTION
* Add `configure_http_client` method that allows for use of proxies and for setting custom timeouts
* Add unit tests for the new `configure_http_client` method
* ~~Adjustment to service files to allow for `x_watson_learning_opt_out` when the object is being initialized~~ Remove potential `x_watson_learning_opt_out` from service initialization. Use `add_default_headers` instead