### PR TITLE
Add AppVeyor CI for testing in a Windows Environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 .DS_Store
 lib/ibm_watson/.swagger-codegen-ignore
 lib/ibm_watson/.swagger-codegen
+test/html_reports/
 
 # Used by dotenv library to load environment variables.
 .env

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -295,7 +295,7 @@ Layout/EndOfLine:
   # The `native` style means that CR+LF (Carriage Return + Line Feed) is
   # enforced on Windows, and LF is enforced on other platforms. The other styles
   # mean LF and CR+LF, respectively.
-  EnforcedStyle: native
+  EnforcedStyle: lf
   SupportedStyles:
     - native
     - lf

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ install:
 script:
 - bundle exec rake
 
+before_deploy:
+  - bundle exec rake test:appveyor_status
+
 deploy:
   - provider: script
     script: npx travis-deploy-once "npx semantic-release"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ If you want to contribute to the repository, follow these steps:
 
 1. Fork the repo.
 2. Test your code changes: `rake` or `rake test`.
-3. Travis-CI will run the tests for all services once your changes are merged.
+3. Travis-CI and AppVeyor will run the tests for all services once your changes are merged.
 4. Add a test for your changes. Only refactoring and documentation changes require no new tests.
 5. Make the test pass.
 6. Commit your changes.
@@ -36,4 +36,4 @@ Ideally, we'd like to see both unit and integration tests on each method.
 Out of the box, `rake` runs integration and unit tests. Put the corresponding credentials in a `.env` file in the root directory for the integration tests to work as intended.
 To just run unit or integration tests, run `rake test:unit` or `rake test:integration`
 
-Currently this enables integration tests for all services so, unless all credentials are supplied, some tests will fail.
+For the integration tests, tests will only be run for services that have credentials defined in a `.env` file.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # IBM Watson Ruby SDK
 
 [![Build Status](https://travis-ci.org/watson-developer-cloud/ruby-sdk.svg)](https://travis-ci.org/watson-developer-cloud/ruby-sdk)
+[![Build status](https://ci.appveyor.com/api/projects/status/ir3k0ue138o4u67e?svg=true)](https://ci.appveyor.com/project/maxnussbaum/ruby-sdk)
 [![Slack](https://wdc-slack-inviter.mybluemix.net/badge.svg)](https://wdc-slack-inviter.mybluemix.net)
 [![codecov.io](https://codecov.io/github/watson-developer-cloud/ruby-sdk/coverage.svg)](https://codecov.io/github/watson-developer-cloud/ruby-sdk)
 [![Gem Version](https://badge.fury.io/rb/ibm_watson.svg)](https://badge.fury.io/rb/ibm_watson)
@@ -275,7 +276,9 @@ Note: `recognize_with_websocket` has been **deprecated** in favor of **`recogniz
 
 ## Ruby version
 
-Tested on Ruby 2.3, 2.4, 2.5
+Tested on:
+* MRI Ruby (RVM): 2.3.7, 2.4.4, 2.5.1
+* RubyInstaller (Windows x64): 2.3.3, 2.4.4, 2.5.1
 
 ## Contributing
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,8 @@ init:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
 
 install:
-  - bundle install --force
+  - bundle install
+  - gem pristine --all
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,14 +11,10 @@ environment:
     - RUBY_VERSION: 25
 
 init:
-  - set PATH=C:\Ruby%RUBY_VERSION%\bin;C:\Program Files\7-Zip;C:\Program Files\AppVeyor\BuildAgent;C:\Program Files\Git\cmd;C:\Windows\system32
+  - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
 
 install:
-  - appveyor DownloadFile https://dl.bintray.com/oneclick/OpenKnapsack/x86/openssl-1.0.2j-x86-windows.tar.lzma &
-      7z e openssl-1.0.2j-x86-windows.tar.lzma &
-      7z x -y openssl-1.0.2j-x86-windows.tar -oC:\ruby23\DevKit\mingw &
-      set b_config="--with-ssl-dir=C:/ruby23/DevKit/mingw --with-opt-include=C:/ruby23/DevKit/mingw/include" &
-      set SSL_CERT_FILE=C:/ruby24-x64/ssl/cert.pem
+  - bundle config build.eventmachine --platform=ruby
   - bundle config --local path vendor/bundle
   - bundle install
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,9 @@ environment:
     - RUBY_VERSION: 25-x64
 
 init:
+  - if "%RUBY_VERSION%"=="23-x64"(
+      set SSL_CERT_FILE=C:/ruby24-x64/ssl/cert.pem
+    )
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,18 +16,12 @@ init:
 install:
   - ps: |
       if ($Env:RUBY_VERSION -match "^23" ) {
-        # RubyInstaller; download OpenSSL headers from OpenKnapsack Project
-        $Env:openssl_dir = "C:\Ruby${Env:RUBY_VERSION}"
-        appveyor DownloadFile http://dl.bintray.com/oneclick/OpenKnapsack/x64/openssl-1.0.2j-x64-windows.tar.lzma
-        7z e openssl-1.0.2j-x64-windows.tar.lzma
-        7z x -y -oC:\Ruby${Env:RUBY_VERSION} openssl-1.0.2j-x64-windows.tar
-      } else {
-        # RubyInstaller2; openssl package seems to be installed already
-        $Env:openssl_dir = "C:\msys64\mingw64"
+        ((New-Object Net.WebClient).DownloadFile('https://curl.haxx.se/ca/cacert.pem', "$env:TMP\ca-cert.pem"))
+        set SSL_CERT_FILE=%TMP%\ca-cert.pem
       }
   - bundle install
   - gem uninstall -a -x --force eventmachine
-  - gem install eventmachine --platform ruby --no-rdoc --no-ri -- --with-ssl-dir=%openssl_dir%
+  - gem install eventmachine --platform ruby --no-rdoc --no-ri
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 version: 1.0.{build}-{branch}
+skip_tags: true
 
 cache:
   - vendor/bundle
@@ -9,8 +10,15 @@ environment:
     - RUBY_VERSION: 24
     - RUBY_VERSION: 25
 
+init:
+  - set PATH=C:\Ruby%RUBY_VERSION%\bin;C:\Program Files\7-Zip;C:\Program Files\AppVeyor\BuildAgent;C:\Program Files\Git\cmd;C:\Windows\system32
+
 install:
-  - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  - appveyor DownloadFile https://dl.bintray.com/oneclick/OpenKnapsack/x86/openssl-1.0.2j-x86-windows.tar.lzma &
+      7z e openssl-1.0.2j-x86-windows.tar.lzma &
+      7z x -y openssl-1.0.2j-x86-windows.tar -oC:\ruby23\DevKit\mingw &
+      set b_config="--with-ssl-dir=C:/ruby23/DevKit/mingw --with-opt-include=C:/ruby23/DevKit/mingw/include" &
+      set SSL_CERT_FILE=C:/ruby24-x64/ssl/cert.pem
   - bundle config --local path vendor/bundle
   - bundle install
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ install:
       }
   - bundle install
   - gem uninstall -a -x --force eventmachine
-  - gem install eventmachine --platform ruby --no-rdoc --no-ri --with-ssl-dir=%openssl_dir%
+  - gem install eventmachine --platform ruby --no-rdoc --no-ri -- --with-ssl-dir=%openssl_dir%
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,9 +14,7 @@ init:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
 
 install:
-  - bundle config build.eventmachine --platform=ruby
-  - bundle config --local path vendor/bundle
-  - bundle install
+  - bundle install --force
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,11 +14,17 @@ init:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
 
 install:
-  - ps: >-
-        appveyor DownloadFile https://dl.bintray.com/oneclick/OpenKnapsack/x64/openssl-1.0.2j-x64-windows.tar.lzma
+  - ps: |
+      if ($Env:RUBY_VERSION -match "^23" ) {
+        # RubyInstaller; download OpenSSL headers from OpenKnapsack Project
+        $Env:openssl_dir = "C:\Ruby${Env:RUBY_VERSION}"
+        appveyor DownloadFile http://dl.bintray.com/oneclick/OpenKnapsack/x64/openssl-1.0.2j-x64-windows.tar.lzma
         7z e openssl-1.0.2j-x64-windows.tar.lzma
-        7z x -y openssl-1.0.2j-x64-windows.tar -o C:\ruby23-x64\DevKit\mingw\x86_64-w64-mingw32
-        # $env:b_config = "--with-ssl-dir=C:/Ruby23-x64/DevKit/mingw --with-opt-include=C:/Ruby23-x64/DevKit/mingw/include"
+        7z x -y -oC:\Ruby${Env:RUBY_VERSION} openssl-1.0.2j-x64-windows.tar
+      } else {
+        # RubyInstaller2; openssl package seems to be installed already
+        $Env:openssl_dir = "C:\msys64\mingw64"
+      }
   - bundle install
   - gem uninstall -a -x --force eventmachine
   - gem install eventmachine --platform ruby --no-rdoc --no-ri

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,9 +6,9 @@ cache:
 
 environment:
   matrix:
-    - RUBY_VERSION: 23
-    - RUBY_VERSION: 24
-    - RUBY_VERSION: 25
+    - RUBY_VERSION: 23-x64
+    - RUBY_VERSION: 24-x64
+    - RUBY_VERSION: 25-x64
 
 init:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,12 +11,14 @@ environment:
     - RUBY_VERSION: 25-x64
 
 init:
-  - if "%RUBY_VERSION%"=="23-x64"(
-      set SSL_CERT_FILE=C:/ruby24-x64/ssl/cert.pem
-    )
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
 
 install:
+  - ps: >-
+        appveyor DownloadFile https://dl.bintray.com/oneclick/OpenKnapsack/x64/openssl-1.0.2j-x64-windows.tar.lzma
+        7z e openssl-1.0.2j-x64-windows.tar.lzma
+        7z x -y openssl-1.0.2j-x64-windows.tar -oC:\ruby23-x64\DevKit\mingw\x86_64-w64-mingw32
+        # $env:b_config = "--with-ssl-dir=C:/Ruby23-x64/DevKit/mingw --with-opt-include=C:/Ruby23-x64/DevKit/mingw/include"
   - bundle install
   - gem uninstall -a -x --force eventmachine
   - gem install eventmachine --platform ruby --no-rdoc --no-ri

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,4 @@
 version: 1.0.{build}-{branch}
-max_jobs: 3
 skip_tags: true
 
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,8 @@ init:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
 
 install:
-  - bundle install --force
-  - gem uninstall -a -x eventmachine
+  - bundle install
+  - gem uninstall -a -x --force eventmachine
   - gem install eventmachine --platform ruby
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,8 @@ init:
 
 install:
   - bundle install --force
+  - gem uninstall -a -x eventmachine
+  - gem install eventmachine --platform ruby
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,8 @@ init:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
 
 install:
+  - bundle config build.eventmachine --platform ruby
   - bundle install
-  - gem pristine --all
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,11 +6,8 @@ cache:
 
 environment:
   matrix:
-    - RUBY_VERSION: 23
     - RUBY_VERSION: 23-x64
-    - RUBY_VERSION: 24
     - RUBY_VERSION: 24-x64
-    - RUBY_VERSION: 25
     - RUBY_VERSION: 25-x64
 
 init:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,8 @@ init:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
 
 install:
-  - bundle config build.eventmachine --platform ruby
   - bundle install
+  - gem install eventmachine --platform ruby
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 version: 1.0.{build}-{branch}
+max_jobs: 3
 skip_tags: true
 
 cache:
@@ -6,8 +7,11 @@ cache:
 
 environment:
   matrix:
+    - RUBY_VERSION: 23
     - RUBY_VERSION: 23-x64
+    - RUBY_VERSION: 24
     - RUBY_VERSION: 24-x64
+    - RUBY_VERSION: 25
     - RUBY_VERSION: 25-x64
 
 init:
@@ -16,7 +20,7 @@ init:
 install:
   - bundle install
   - gem uninstall -a -x --force eventmachine
-  - gem install eventmachine --platform ruby
+  - gem install eventmachine --platform ruby --no-rdoc --no-ri
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ install:
   - ps: >-
         appveyor DownloadFile https://dl.bintray.com/oneclick/OpenKnapsack/x64/openssl-1.0.2j-x64-windows.tar.lzma
         7z e openssl-1.0.2j-x64-windows.tar.lzma
-        7z x -y openssl-1.0.2j-x64-windows.tar -oC:\ruby23-x64\DevKit\mingw\x86_64-w64-mingw32
+        7z x -y openssl-1.0.2j-x64-windows.tar -o C:\ruby23-x64\DevKit\mingw\x86_64-w64-mingw32
         # $env:b_config = "--with-ssl-dir=C:/Ruby23-x64/DevKit/mingw --with-opt-include=C:/Ruby23-x64/DevKit/mingw/include"
   - bundle install
   - gem uninstall -a -x --force eventmachine

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,7 @@ init:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
 
 install:
-  - bundle install
-  - gem install eventmachine --platform ruby
+  - bundle install --force
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ install:
       }
   - bundle install
   - gem uninstall -a -x --force eventmachine
-  - gem install eventmachine --platform ruby --no-rdoc --no-ri
+  - gem install eventmachine --platform ruby --no-rdoc --no-ri --with-ssl-dir=%openssl_dir%
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,29 @@
+version: 1.0.{build}-{branch}
+
+cache:
+  - vendor/bundle
+
+environment:
+  matrix:
+    - RUBY_VERSION: 23
+    - RUBY_VERSION: 24
+    - RUBY_VERSION: 25
+
+install:
+  - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  - bundle config --local path vendor/bundle
+  - bundle install
+
+build: off
+
+before_test:
+  - ruby -v
+  - gem -v
+  - bundle -v
+
+test_script:
+  - bundle exec rake
+
+deploy: off
+matrix:
+  fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,12 +16,19 @@ init:
 install:
   - ps: |
       if ($Env:RUBY_VERSION -match "^23" ) {
-        ((New-Object Net.WebClient).DownloadFile('https://curl.haxx.se/ca/cacert.pem', "$env:TMP\ca-cert.pem"))
-        set SSL_CERT_FILE=%TMP%\ca-cert.pem
+        # RubyInstaller; download OpenSSL headers from OpenKnapsack Project
+        $Env:openssl_dir = "C:\Ruby${Env:RUBY_VERSION}"
+        appveyor DownloadFile http://dl.bintray.com/oneclick/OpenKnapsack/x64/openssl-1.0.2j-x64-windows.tar.lzma
+        7z e openssl-1.0.2j-x64-windows.tar.lzma
+        7z x -y -oC:\Ruby${Env:RUBY_VERSION} openssl-1.0.2j-x64-windows.tar
+      } else {
+        # RubyInstaller2; openssl package seems to be installed already
+        $Env:openssl_dir = "C:\msys64\mingw64"
       }
+  - set SSL_CERT_FILE=C:/ruby24-x64/ssl/cert.pem
   - bundle install
   - gem uninstall -a -x --force eventmachine
-  - gem install eventmachine --platform ruby --no-rdoc --no-ri
+  - gem install eventmachine --platform ruby --no-rdoc --no-ri -- --with-ssl-dir=%openssl_dir%
 
 build: off
 

--- a/ibm_watson.gemspec
+++ b/ibm_watson.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "httplog", "~> 1.0"
   spec.add_development_dependency "minitest", "~> 5.11"
   spec.add_development_dependency "minitest-hooks", "~> 1.5"
+  spec.add_development_dependency "minitest-reporters", "~> 1.3"
   spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "rubocop", "~> 0.57"
   spec.add_development_dependency "simplecov", "~> 0.16"

--- a/ibm_watson.gemspec
+++ b/ibm_watson.gemspec
@@ -44,6 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.11"
   spec.add_development_dependency "minitest-hooks", "~> 1.5"
   spec.add_development_dependency "minitest-reporters", "~> 1.3"
+  spec.add_development_dependency "minitest-retry", "~> 0.1"
   spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "rubocop", "~> 0.57"
   spec.add_development_dependency "simplecov", "~> 0.16"

--- a/rakefile
+++ b/rakefile
@@ -26,7 +26,7 @@ namespace :test do
     t.test_files = FileList["test/integration/*.rb"]
     t.verbose = true
     t.warning = true
-    t.deps = [:dotenv, :rubocop]
+    t.deps = %i[dotenv rubocop]
   end
 end
 

--- a/rakefile
+++ b/rakefile
@@ -28,6 +28,15 @@ namespace :test do
     t.warning = true
     t.deps = %i[dotenv rubocop]
   end
+
+  Rake::TestTask.new do |t|
+    t.name = "appveyor_status"
+    t.description = "Checks to ensure that AppVeyor tests pass before deploying from Travis"
+    t.libs << "test"
+    t.test_files = FileList["test/appveyor_status.rb"]
+    t.verbose = false
+    t.warning = false
+  end
 end
 
 desc "Run unit & integration tests"

--- a/rakefile
+++ b/rakefile
@@ -16,6 +16,7 @@ namespace :test do
     t.test_files = FileList["test/unit/*.rb"]
     t.verbose = true
     t.warning = true
+    t.deps = [:rubocop]
   end
 
   Rake::TestTask.new do |t|
@@ -25,7 +26,7 @@ namespace :test do
     t.test_files = FileList["test/integration/*.rb"]
     t.verbose = true
     t.warning = true
-    t.deps = [:dotenv]
+    t.deps = [:dotenv, :rubocop]
   end
 end
 
@@ -41,5 +42,5 @@ task :coverage do
   Rake::Task["test"].execute
 end
 
-task def: %i[rubocop coverage] do
+task def: %i[coverage] do
 end

--- a/test/appveyor_status.rb
+++ b/test/appveyor_status.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require("minitest/reporters")
+require("minitest/autorun")
+require("minitest/retry")
+require("http")
+require("json")
+
+Minitest::Retry.use!
+Minitest::Reporters.use! [Minitest::Reporters::DefaultReporter.new(color: true), Minitest::Reporters::SpecReporter.new]
+
+# Test to run from Travis to ensure that AppVeyor tests pass before attempting to deploy to RubyGems
+class AppVeyorStatusTest < Minitest::Test
+  def test_appveyor_status
+    skip "Branch is NOT master and/or Ruby != 2.5.1, so AppVeyor check before deployment will not be run." if ENV["TRAVIS_BRANCH"] != "master" || ENV["TRAVIS_RUBY_VERSION"] != "2.5.1"
+    client = HTTP::Client.new
+    status = JSON.parse(client.get("https://ci.appveyor.com/api/projects/maxnussbaum/ruby-sdk").body.to_s)["build"]["status"]
+    while status != "success" && status != "failed" && status != "cancelled"
+      sleep(3)
+      status = JSON.parse(client.get("https://ci.appveyor.com/api/projects/maxnussbaum/ruby-sdk").body.to_s)["build"]["status"]
+    end
+    if status == "success"
+      assert(true)
+    else
+      assert(false, "AppVeyor tests have NOT passed! Please ensure that AppVeyor passes before deploying")
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,8 +2,11 @@
 
 require("simplecov")
 require("codecov")
+require("minitest/reporters")
 
 if ENV["COVERAGE"]
+  Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new, Minitest::Reporters::HtmlReporter.new] if ENV["CI"].nil?
+  Minitest::Reporters.use!(Minitest::Reporters::SpecReporter.new) if ENV["CI"]
   SimpleCov.formatter = SimpleCov::Formatter::Codecov if ENV["CI"]
   unless SimpleCov.running
     SimpleCov.start do
@@ -18,7 +21,4 @@ if ENV["COVERAGE"]
 end
 
 require("minitest/autorun")
-require("minitest/reporters")
 require_relative("./../lib/ibm_watson.rb")
-
-Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new, Minitest::Reporters::HtmlReporter.new]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,5 +24,5 @@ require("minitest/retry")
 
 Minitest::Retry.use!
 
-Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new, Minitest::Reporters::HtmlReporter.new] if ENV["CI"].nil?
-Minitest::Reporters.use!(Minitest::Reporters::SpecReporter.new) if ENV["CI"]
+Minitest::Reporters.use! [Minitest::Reporters::DefaultReporter.new(color: true, slow_count: 10), Minitest::Reporters::SpecReporter.new, Minitest::Reporters::HtmlReporter.new] if ENV["CI"].nil?
+Minitest::Reporters.use! [Minitest::Reporters::DefaultReporter.new(color: true, slow_count: 10), Minitest::Reporters::SpecReporter.new] if ENV["CI"]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,6 +20,9 @@ end
 
 require("minitest/autorun")
 require_relative("./../lib/ibm_watson.rb")
+require("minitest/retry")
+
+Minitest::Retry.use!
 
 Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new, Minitest::Reporters::HtmlReporter.new] if ENV["CI"].nil?
 Minitest::Reporters.use!(Minitest::Reporters::SpecReporter.new) if ENV["CI"]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,8 +5,6 @@ require("codecov")
 require("minitest/reporters")
 
 if ENV["COVERAGE"]
-  Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new, Minitest::Reporters::HtmlReporter.new] if ENV["CI"].nil?
-  Minitest::Reporters.use!(Minitest::Reporters::SpecReporter.new) if ENV["CI"]
   SimpleCov.formatter = SimpleCov::Formatter::Codecov if ENV["CI"]
   unless SimpleCov.running
     SimpleCov.start do
@@ -22,3 +20,6 @@ end
 
 require("minitest/autorun")
 require_relative("./../lib/ibm_watson.rb")
+
+Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new, Minitest::Reporters::HtmlReporter.new] if ENV["CI"].nil?
+Minitest::Reporters.use!(Minitest::Reporters::SpecReporter.new) if ENV["CI"]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,4 +18,7 @@ if ENV["COVERAGE"]
 end
 
 require("minitest/autorun")
+require("minitest/reporters")
 require_relative("./../lib/ibm_watson.rb")
+
+Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new, Minitest::Reporters::HtmlReporter.new]


### PR DESCRIPTION
* Add **AppVeyor-CI** to have testing be run in a Windows Environment
* Make **AppVeyor** a required test to pass for PRs
* Require **AppVeyor** tests to pass before a deploy is attempted in **Travis**
* Add retry for tests (maximum 3 attempts)
* Improve how test results are displayed
* **AppVeyor** currently runs
  * all `unit tests`
  * only `integration tests` for `speech-to-text` and `discovery` (this can be changed. I just need to add the credentials to the environment)
* https://ci.appveyor.com/project/maxnussbaum/ruby-sdk
* This will probably need to be migrated to a central account on appveyor (i.e. not mine)