### PR TITLE
fix(visualRecognition): classifier_ids should be passed to classify as an array of strings

### DIFF
--- a/lib/ibm_watson/visual_recognition_v3.rb
+++ b/lib/ibm_watson/visual_recognition_v3.rb
@@ -140,9 +140,6 @@ module IBMWatson
           images_file = images_file.instance_of?(StringIO) ? HTTP::FormData::File.new(images_file, content_type: mime_type) : HTTP::FormData::File.new(images_file.path, content_type: mime_type)
         end
       end
-      threshold = HTTP::FormData::Part.new(threshold, content_type: "text/plain") unless threshold.nil?
-      owners = HTTP::FormData::Part.new(owners, content_type: "text/plain") unless owners.nil?
-      classifier_ids = HTTP::FormData::Part.new(classifier_ids, content_type: "text/plain") unless classifier_ids.nil?
       method_url = "/v3/classify"
       response = request(
         method: "POST",

--- a/test/integration/test_visual_recognition_v3.rb
+++ b/test/integration/test_visual_recognition_v3.rb
@@ -29,7 +29,7 @@ if !ENV["VISUAL_RECOGNITION_IAM_APIKEY"].nil? && !ENV["VISUAL_RECOGNITION_IAM_UR
       dog_results = @service.classify(
         images_file: image_file,
         threshold: "0.1",
-        classifier_ids: "default"
+        classifier_ids: %w[default food]
       ).result
       refute(dog_results.nil?)
     end


### PR DESCRIPTION
fixes: https://github.com/watson-developer-cloud/ruby-sdk/issues/20