### PR TITLE
Remove travis-deploy-once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_deploy:
 
 deploy:
   - provider: script
-    script: npx travis-deploy-once "npx semantic-release"
+    script: npx semantic-release
     on:
       branch: master
       rvm: 2.5.1


### PR DESCRIPTION
This PR removes the use of `travis-deploy-once` from the deploy script. There must be a bug in the latest release of that package, because there have been errors complaining of a missing module in all of the SDKs using this. Removing it has cleared things up though, and we can investigate and add it back later.