### PR TITLE
build: make rubocop to use 0.62.0 for now

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.1
+current_version = 0.10.0
 commit = True
 message = [skip ci] Bump version: {current_version} -> {new_version}
 

--- a/ibm_watson.gemspec
+++ b/ibm_watson.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest-reporters", "~> 1.3"
   spec.add_development_dependency "minitest-retry", "~> 0.1"
   spec.add_development_dependency "rake", "~> 12.3"
-  spec.add_development_dependency "rubocop", "~> 0.57"
+  spec.add_development_dependency "rubocop", "0.62"
   spec.add_development_dependency "simplecov", "~> 0.16"
   spec.add_development_dependency "webmock", "~> 3.4"
 end


### PR DESCRIPTION
Rubocop released [0.63.0](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) a few hours ago and it's causing the [build](https://travis-ci.org/watson-developer-cloud/ruby-sdk/jobs/480509148) to fail. We need to make changes to config for robocop, and it's also buggy right now:

![screen shot 2019-01-16 at 1 37 38 pm](https://user-images.githubusercontent.com/16810846/51271131-b724b080-1994-11e9-842d-b6715b5e039d.png)
