### PR TITLE
Update examples, readme and common

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ assistant.configure_http_client(
 
 The HTTP client can be configured to disable SSL verification. Note that this has serious security implications - only do this if you really mean to! ⚠️
 
-To do this, pass `disable_ssl` as `true` in `configure_http_client()`, like below:
+To do this, pass `disable_ssl_verification` as `true` in `configure_http_client()`, like below:
 
 ```ruby
 require "ibm_watson/assistant_v1"
@@ -298,7 +298,7 @@ service = AssistantV1.new(
   password: "<password>",
 )
 
-service.configure_http_client(disable_ssl: true)
+service.configure_http_client(disable_ssl_verification: true)
 ```
 
 ## Using Websockets

--- a/examples/speech_to_text_v1.rb
+++ b/examples/speech_to_text_v1.rb
@@ -98,3 +98,30 @@ Thread.new do
 end
 thr = Thread.new { speech.start }
 thr.join
+
+# Example using websockets using multiple threads for two audio files
+# Make sure you create two wrappers of service and then start the threads
+speech = speech_to_text.recognize_using_websocket(
+  audio: File.open(Dir.getwd + "/resources/speech.wav"),
+  recognize_callback: MyRecognizeCallback.new,
+  interim_results: true,
+  timestamps: true,
+  max_alternatives: 2,
+  word_alternatives_threshold: 0.5,
+  content_type: "audio/wav"
+)
+
+speech_2 = speech_to_text.recognize_using_websocket(
+  audio: File.open(Dir.getwd + "/resources/sound-with-pause.wav"),
+  recognize_callback: MyRecognizeCallback.new,
+  interim_results: true,
+  timestamps: true,
+  max_alternatives: 2,
+  word_alternatives_threshold: 0.5,
+  content_type: "audio/wav"
+)
+
+thr = Thread.new { speech.start }
+thr_2 = Thread.new { speech_2.start }
+thr.join
+thr_2.join

--- a/examples/speech_to_text_v1.rb
+++ b/examples/speech_to_text_v1.rb
@@ -111,7 +111,7 @@ speech = speech_to_text.recognize_using_websocket(
   content_type: "audio/wav"
 )
 
-speech_2 = speech_to_text.recognize_using_websocket(
+speech_with_pause = speech_to_text.recognize_using_websocket(
   audio: File.open(Dir.getwd + "/resources/sound-with-pause.wav"),
   recognize_callback: MyRecognizeCallback.new,
   interim_results: true,
@@ -121,7 +121,8 @@ speech_2 = speech_to_text.recognize_using_websocket(
   content_type: "audio/wav"
 )
 
-thr = Thread.new { speech.start }
-thr_2 = Thread.new { speech_2.start }
-thr.join
-thr_2.join
+main_thread = Thread.new { speech.start }
+another_thread = Thread.new { speech_with_pause.start }
+
+main_thread.join
+another_thread.join

--- a/lib/ibm_watson/common.rb
+++ b/lib/ibm_watson/common.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "./version.rb"
+
 module IBMWatson
   # SDK Common class
   class Common


### PR DESCRIPTION
- Adds an example on how to use WebSockets with multiple threads. Related to https://github.com/watson-developer-cloud/ruby-sdk/issues/39
- Import version in common so that the user does not need to import the whole module for one service
- Update `disable_ssl` in readme.