### PR TITLE
Refactor bluemix to cloud.ibm

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,8 +10,8 @@ assignees: ''
 **Service Status**
 Please review the following:
 
-- If the bug is because of the service issue, and service is throwing 5xx error, please go to https://console.bluemix.net/status?tags=platform,runtimes,services&view=n:i and check the status of the service.
-- If it's not a service issue, please continue with a bug report.
+-  For service issues or 5xx errors, first, go to the [IBM Cloud status page](https://cloud.ibm.com/status?component=compare-comply%2Cdiscovery%2Cconversation%2Cwatson-vision-combined%2Cnatural-language-understanding%2Cnatural-language-classifier%2Clanguage-translator%2Cpersonality-insights%2Cspeech-to-text%2Ctext-to-speech%2Ctone-analyzer&selected=status) and check the status of the service.
+-  If the service status is OK, continue with a bug report.
 
 **Describe the bug**
 A clear and concise description of what the bug is. 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ IBM Cloud is migrating to token-based Identity and Access Management (IAM) authe
 You supply either an IAM service **API key** or an **access token**:
 
 - Use the API key to have the SDK manage the lifecycle of the access token. The SDK requests an access token, ensures that the access token is valid, and refreshes it if necessary.
-- Use the access token if you want to manage the lifecycle yourself. For details, see [Authenticating with IAM tokens](https://console.bluemix.net/docs/services/watson/getting-started-iam.html).
+- Use the access token if you want to manage the lifecycle yourself. For details, see [Authenticating with IAM tokens](https://cloud.ibm.com/docs/services/watson?topic=watson-iam).
 
 #### Supplying the IAM API key
 
@@ -133,7 +133,7 @@ You supply either an IAM service **API key** or an **access token**:
 discovery = IBMWatson::DiscoveryV1.new(
   version: "2017-10-16",
   iam_apikey: "<iam_apikey>",
-  iam_url: "<iam_url>" # optional - the default value is https://iam.ng.bluemix.net/identity/token
+  iam_url: "<iam_url>" # optional - the default value is https://iam.cloud.ibm.com/identity/token
 )
 ```
 
@@ -364,11 +364,11 @@ Here are some projects that have been using the SDK:
 We'd love to highlight cool open-source projects that use this SDK! If you'd like to get your project added to the list, feel free to make an issue linking us to it.
 
 [wdc]: http://www.ibm.com/watson/developercloud/
-[ibm_cloud]: https://console.bluemix.net
-[watson-dashboard]: https://console.bluemix.net/dashboard/apps?category=ai
+[ibm_cloud]: https://cloud.ibm.com/
+[watson-dashboard]: https://cloud.ibm.com/catalog?category=ai
 [examples]: https://github.com/watson-developer-cloud/ruby-sdk/tree/master/examples
 [CONTRIBUTING]: https://github.com/watson-developer-cloud/ruby-sdk/blob/master/CONTRIBUTING.md
 [license]: http://www.apache.org/licenses/LICENSE-2.0
-[vcap_services]: https://console.bluemix.net/docs/services/watson/getting-started-variables.html
-[ibm-cloud-onboarding]: http://console.bluemix.net/registration?target=/developer/watson&cm_sp=WatsonPlatform-WatsonServices-_-OnPageNavLink-IBMWatson_SDKs-_-Ruby
+[vcap_services]: https://cloud.ibm.com/docs/services/watson?topic=watson-vcapServices
+[ibm-cloud-onboarding]: http://cloud.ibm.com/registration?target=/developer/watson&cm_sp=WatsonPlatform-WatsonServices-_-OnPageNavLink-IBMWatson_SDKs-_-Ruby
 [ivar]: http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/IVar.html

--- a/ibm_watson.gemspec
+++ b/ibm_watson.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "eventmachine", "~> 1.2"
   spec.add_runtime_dependency "faye-websocket", "~> 0.10"
   spec.add_runtime_dependency "http", "~> 4.1.0"
-  spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 0.1.1"
+  spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 0.2.0"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "codecov", "~> 0.1"

--- a/ibm_watson.gemspec
+++ b/ibm_watson.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   if spec.respond_to?(:metadata)
     spec.metadata["allowed_push_host"] = "https://rubygems.org"
     spec.metadata["source_code_uri"] = "https://github.com/watson-developer-cloud/ruby-sdk"
-    spec.metadata["documentation_uri"] = "https://console.bluemix.net/developer/watson/documentation"
+    spec.metadata["documentation_uri"] = "https://cloud.ibm.com/developer/watson/documentation"
   else
     raise "RubyGems 2.0 or newer is required to protect against " \
       "public gem pushes."

--- a/lib/ibm_watson/assistant_v1.rb
+++ b/lib/ibm_watson/assistant_v1.rb
@@ -47,16 +47,16 @@ module IBMWatson
     #   ready for a later version.
     # @option args url [String] The base url to use when contacting the service (e.g.
     #   "https://gateway.watsonplatform.net/assistant/api").
-    #   The base url may differ between Bluemix regions.
+    #   The base url may differ between IBM Cloud regions.
     # @option args username [String] The username used to authenticate with the service.
     #   Username and password credentials are only required to run your
-    #   application locally or outside of Bluemix. When running on
-    #   Bluemix, the credentials will be automatically loaded from the
+    #   application locally or outside of IBM Cloud. When running on
+    #   IBM Cloud, the credentials will be automatically loaded from the
     #   `VCAP_SERVICES` environment variable.
     # @option args password [String] The password used to authenticate with the service.
     #   Username and password credentials are only required to run your
-    #   application locally or outside of Bluemix. When running on
-    #   Bluemix, the credentials will be automatically loaded from the
+    #   application locally or outside of IBM Cloud. When running on
+    #   IBM Cloud, the credentials will be automatically loaded from the
     #   `VCAP_SERVICES` environment variable.
     # @option args iam_apikey [String] An API key that can be used to request IAM tokens. If
     #   this API key is provided, the SDK will manage the token and handle the
@@ -66,7 +66,7 @@ module IBMWatson
     #   it expires or reactively upon receiving a 401 from the service as any requests
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
-    #   'https://iam.ng.bluemix.net/identity/token'.
+    #   'https://iam.cloud.ibm.com/identity/token'.
     def initialize(args = {})
       @__async_initialized__ = false
       defaults = {}

--- a/lib/ibm_watson/assistant_v2.rb
+++ b/lib/ibm_watson/assistant_v2.rb
@@ -47,16 +47,16 @@ module IBMWatson
     #   ready for a later version.
     # @option args url [String] The base url to use when contacting the service (e.g.
     #   "https://gateway.watsonplatform.net/assistant/api").
-    #   The base url may differ between Bluemix regions.
+    #   The base url may differ between IBM Cloud regions.
     # @option args username [String] The username used to authenticate with the service.
     #   Username and password credentials are only required to run your
-    #   application locally or outside of Bluemix. When running on
-    #   Bluemix, the credentials will be automatically loaded from the
+    #   application locally or outside of IBM Cloud. When running on
+    #   IBM Cloud, the credentials will be automatically loaded from the
     #   `VCAP_SERVICES` environment variable.
     # @option args password [String] The password used to authenticate with the service.
     #   Username and password credentials are only required to run your
-    #   application locally or outside of Bluemix. When running on
-    #   Bluemix, the credentials will be automatically loaded from the
+    #   application locally or outside of IBM Cloud. When running on
+    #   IBM Cloud, the credentials will be automatically loaded from the
     #   `VCAP_SERVICES` environment variable.
     # @option args iam_apikey [String] An API key that can be used to request IAM tokens. If
     #   this API key is provided, the SDK will manage the token and handle the
@@ -66,7 +66,7 @@ module IBMWatson
     #   it expires or reactively upon receiving a 401 from the service as any requests
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
-    #   'https://iam.ng.bluemix.net/identity/token'.
+    #   'https://iam.cloud.ibm.com/identity/token'.
     def initialize(args = {})
       @__async_initialized__ = false
       defaults = {}
@@ -96,7 +96,7 @@ module IBMWatson
     # @param assistant_id [String] Unique identifier of the assistant. You can find the assistant ID of an assistant
     #   on the **Assistants** tab of the Watson Assistant tool. For information about
     #   creating assistants, see the
-    #   [documentation](https://console.bluemix.net/docs/services/assistant/assistant-add.html#assistant-add-task).
+    #   [documentation](https://cloud.ibm.com/docs/services/assistant?topic=assistant-assistant-add#assistant-add-task).
     #
     #   **Note:** Currently, the v2 API does not support creating assistants.
     # @return [IBMCloudSdkCore::DetailedResponse] A `IBMCloudSdkCore::DetailedResponse` object representing the response.
@@ -131,7 +131,7 @@ module IBMWatson
     # @param assistant_id [String] Unique identifier of the assistant. You can find the assistant ID of an assistant
     #   on the **Assistants** tab of the Watson Assistant tool. For information about
     #   creating assistants, see the
-    #   [documentation](https://console.bluemix.net/docs/services/assistant/assistant-add.html#assistant-add-task).
+    #   [documentation](https://cloud.ibm.com/docs/services/assistant?topic=assistant-assistant-add#assistant-add-task).
     #
     #   **Note:** Currently, the v2 API does not support creating assistants.
     # @param session_id [String] Unique identifier of the session.
@@ -174,7 +174,7 @@ module IBMWatson
     # @param assistant_id [String] Unique identifier of the assistant. You can find the assistant ID of an assistant
     #   on the **Assistants** tab of the Watson Assistant tool. For information about
     #   creating assistants, see the
-    #   [documentation](https://console.bluemix.net/docs/services/assistant/assistant-add.html#assistant-add-task).
+    #   [documentation](https://cloud.ibm.com/docs/services/assistant?topic=assistant-assistant-add#assistant-add-task).
     #
     #   **Note:** Currently, the v2 API does not support creating assistants.
     # @param session_id [String] Unique identifier of the session.

--- a/lib/ibm_watson/compare_comply_v1.rb
+++ b/lib/ibm_watson/compare_comply_v1.rb
@@ -46,7 +46,7 @@ module IBMWatson
     #   ready for a later version.
     # @option args url [String] The base url to use when contacting the service (e.g.
     #   "https://gateway.watsonplatform.net/compare-comply/api").
-    #   The base url may differ between Bluemix regions.
+    #   The base url may differ between IBM Cloud regions.
     # @option args iam_apikey [String] An API key that can be used to request IAM tokens. If
     #   this API key is provided, the SDK will manage the token and handle the
     #   refreshing.
@@ -55,7 +55,7 @@ module IBMWatson
     #   it expires or reactively upon receiving a 401 from the service as any requests
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
-    #   'https://iam.ng.bluemix.net/identity/token'.
+    #   'https://iam.cloud.ibm.com/identity/token'.
     def initialize(args = {})
       @__async_initialized__ = false
       defaults = {}

--- a/lib/ibm_watson/discovery_v1.rb
+++ b/lib/ibm_watson/discovery_v1.rb
@@ -49,16 +49,16 @@ module IBMWatson
     #   ready for a later version.
     # @option args url [String] The base url to use when contacting the service (e.g.
     #   "https://gateway.watsonplatform.net/discovery/api").
-    #   The base url may differ between Bluemix regions.
+    #   The base url may differ between IBM Cloud regions.
     # @option args username [String] The username used to authenticate with the service.
     #   Username and password credentials are only required to run your
-    #   application locally or outside of Bluemix. When running on
-    #   Bluemix, the credentials will be automatically loaded from the
+    #   application locally or outside of IBM Cloud. When running on
+    #   IBM Cloud, the credentials will be automatically loaded from the
     #   `VCAP_SERVICES` environment variable.
     # @option args password [String] The password used to authenticate with the service.
     #   Username and password credentials are only required to run your
-    #   application locally or outside of Bluemix. When running on
-    #   Bluemix, the credentials will be automatically loaded from the
+    #   application locally or outside of IBM Cloud. When running on
+    #   IBM Cloud, the credentials will be automatically loaded from the
     #   `VCAP_SERVICES` environment variable.
     # @option args iam_apikey [String] An API key that can be used to request IAM tokens. If
     #   this API key is provided, the SDK will manage the token and handle the
@@ -68,7 +68,7 @@ module IBMWatson
     #   it expires or reactively upon receiving a 401 from the service as any requests
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
-    #   'https://iam.ng.bluemix.net/identity/token'.
+    #   'https://iam.cloud.ibm.com/identity/token'.
     def initialize(args = {})
       @__async_initialized__ = false
       defaults = {}

--- a/lib/ibm_watson/language_translator_v3.rb
+++ b/lib/ibm_watson/language_translator_v3.rb
@@ -49,16 +49,16 @@ module IBMWatson
     #   ready for a later version.
     # @option args url [String] The base url to use when contacting the service (e.g.
     #   "https://gateway.watsonplatform.net/language-translator/api").
-    #   The base url may differ between Bluemix regions.
+    #   The base url may differ between IBM Cloud regions.
     # @option args username [String] The username used to authenticate with the service.
     #   Username and password credentials are only required to run your
-    #   application locally or outside of Bluemix. When running on
-    #   Bluemix, the credentials will be automatically loaded from the
+    #   application locally or outside of IBM Cloud. When running on
+    #   IBM Cloud, the credentials will be automatically loaded from the
     #   `VCAP_SERVICES` environment variable.
     # @option args password [String] The password used to authenticate with the service.
     #   Username and password credentials are only required to run your
-    #   application locally or outside of Bluemix. When running on
-    #   Bluemix, the credentials will be automatically loaded from the
+    #   application locally or outside of IBM Cloud. When running on
+    #   IBM Cloud, the credentials will be automatically loaded from the
     #   `VCAP_SERVICES` environment variable.
     # @option args iam_apikey [String] An API key that can be used to request IAM tokens. If
     #   this API key is provided, the SDK will manage the token and handle the
@@ -68,7 +68,7 @@ module IBMWatson
     #   it expires or reactively upon receiving a 401 from the service as any requests
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
-    #   'https://iam.ng.bluemix.net/identity/token'.
+    #   'https://iam.cloud.ibm.com/identity/token'.
     def initialize(args = {})
       @__async_initialized__ = false
       defaults = {}

--- a/lib/ibm_watson/natural_language_classifier_v1.rb
+++ b/lib/ibm_watson/natural_language_classifier_v1.rb
@@ -38,16 +38,16 @@ module IBMWatson
     # @param args [Hash] The args to initialize with
     # @option args url [String] The base url to use when contacting the service (e.g.
     #   "https://gateway.watsonplatform.net/natural-language-classifier/api").
-    #   The base url may differ between Bluemix regions.
+    #   The base url may differ between IBM Cloud regions.
     # @option args username [String] The username used to authenticate with the service.
     #   Username and password credentials are only required to run your
-    #   application locally or outside of Bluemix. When running on
-    #   Bluemix, the credentials will be automatically loaded from the
+    #   application locally or outside of IBM Cloud. When running on
+    #   IBM Cloud, the credentials will be automatically loaded from the
     #   `VCAP_SERVICES` environment variable.
     # @option args password [String] The password used to authenticate with the service.
     #   Username and password credentials are only required to run your
-    #   application locally or outside of Bluemix. When running on
-    #   Bluemix, the credentials will be automatically loaded from the
+    #   application locally or outside of IBM Cloud. When running on
+    #   IBM Cloud, the credentials will be automatically loaded from the
     #   `VCAP_SERVICES` environment variable.
     # @option args iam_apikey [String] An API key that can be used to request IAM tokens. If
     #   this API key is provided, the SDK will manage the token and handle the
@@ -57,7 +57,7 @@ module IBMWatson
     #   it expires or reactively upon receiving a 401 from the service as any requests
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
-    #   'https://iam.ng.bluemix.net/identity/token'.
+    #   'https://iam.cloud.ibm.com/identity/token'.
     def initialize(args = {})
       @__async_initialized__ = false
       defaults = {}

--- a/lib/ibm_watson/natural_language_understanding_v1.rb
+++ b/lib/ibm_watson/natural_language_understanding_v1.rb
@@ -53,16 +53,16 @@ module IBMWatson
     #   ready for a later version.
     # @option args url [String] The base url to use when contacting the service (e.g.
     #   "https://gateway.watsonplatform.net/natural-language-understanding/api").
-    #   The base url may differ between Bluemix regions.
+    #   The base url may differ between IBM Cloud regions.
     # @option args username [String] The username used to authenticate with the service.
     #   Username and password credentials are only required to run your
-    #   application locally or outside of Bluemix. When running on
-    #   Bluemix, the credentials will be automatically loaded from the
+    #   application locally or outside of IBM Cloud. When running on
+    #   IBM Cloud, the credentials will be automatically loaded from the
     #   `VCAP_SERVICES` environment variable.
     # @option args password [String] The password used to authenticate with the service.
     #   Username and password credentials are only required to run your
-    #   application locally or outside of Bluemix. When running on
-    #   Bluemix, the credentials will be automatically loaded from the
+    #   application locally or outside of IBM Cloud. When running on
+    #   IBM Cloud, the credentials will be automatically loaded from the
     #   `VCAP_SERVICES` environment variable.
     # @option args iam_apikey [String] An API key that can be used to request IAM tokens. If
     #   this API key is provided, the SDK will manage the token and handle the
@@ -72,7 +72,7 @@ module IBMWatson
     #   it expires or reactively upon receiving a 401 from the service as any requests
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
-    #   'https://iam.ng.bluemix.net/identity/token'.
+    #   'https://iam.cloud.ibm.com/identity/token'.
     def initialize(args = {})
       @__async_initialized__ = false
       defaults = {}
@@ -129,8 +129,8 @@ module IBMWatson
     # @param language [String] ISO 639-1 code that specifies the language of your text. This overrides automatic
     #   language detection. Language support differs depending on the features you include
     #   in your analysis. See [Language
-    #   support](https://www.bluemix.net/docs/services/natural-language-understanding/language-support.html)
-    #   for more information.
+    #   support](https://cloud.ibm.com/docs/services/natural-language-understanding?topic=natural-language-
+    #   understanding-language-support) for more information.
     # @param limit_text_characters [Fixnum] Sets the maximum number of characters that are processed by the service.
     # @return [IBMCloudSdkCore::DetailedResponse] A `IBMCloudSdkCore::DetailedResponse` object representing the response.
     def analyze(features:, text: nil, html: nil, url: nil, clean: nil, xpath: nil, fallback_to_raw: nil, return_analyzed_text: nil, language: nil, limit_text_characters: nil)

--- a/lib/ibm_watson/personality_insights_v3.rb
+++ b/lib/ibm_watson/personality_insights_v3.rb
@@ -64,16 +64,16 @@ module IBMWatson
     #   ready for a later version.
     # @option args url [String] The base url to use when contacting the service (e.g.
     #   "https://gateway.watsonplatform.net/personality-insights/api").
-    #   The base url may differ between Bluemix regions.
+    #   The base url may differ between IBM Cloud regions.
     # @option args username [String] The username used to authenticate with the service.
     #   Username and password credentials are only required to run your
-    #   application locally or outside of Bluemix. When running on
-    #   Bluemix, the credentials will be automatically loaded from the
+    #   application locally or outside of IBM Cloud. When running on
+    #   IBM Cloud, the credentials will be automatically loaded from the
     #   `VCAP_SERVICES` environment variable.
     # @option args password [String] The password used to authenticate with the service.
     #   Username and password credentials are only required to run your
-    #   application locally or outside of Bluemix. When running on
-    #   Bluemix, the credentials will be automatically loaded from the
+    #   application locally or outside of IBM Cloud. When running on
+    #   IBM Cloud, the credentials will be automatically loaded from the
     #   `VCAP_SERVICES` environment variable.
     # @option args iam_apikey [String] An API key that can be used to request IAM tokens. If
     #   this API key is provided, the SDK will manage the token and handle the
@@ -83,7 +83,7 @@ module IBMWatson
     #   it expires or reactively upon receiving a 401 from the service as any requests
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
-    #   'https://iam.ng.bluemix.net/identity/token'.
+    #   'https://iam.cloud.ibm.com/identity/token'.
     def initialize(args = {})
       @__async_initialized__ = false
       defaults = {}

--- a/lib/ibm_watson/speech_to_text_v1.rb
+++ b/lib/ibm_watson/speech_to_text_v1.rb
@@ -57,16 +57,16 @@ module IBMWatson
     # @param args [Hash] The args to initialize with
     # @option args url [String] The base url to use when contacting the service (e.g.
     #   "https://stream.watsonplatform.net/speech-to-text/api").
-    #   The base url may differ between Bluemix regions.
+    #   The base url may differ between IBM Cloud regions.
     # @option args username [String] The username used to authenticate with the service.
     #   Username and password credentials are only required to run your
-    #   application locally or outside of Bluemix. When running on
-    #   Bluemix, the credentials will be automatically loaded from the
+    #   application locally or outside of IBM Cloud. When running on
+    #   IBM Cloud, the credentials will be automatically loaded from the
     #   `VCAP_SERVICES` environment variable.
     # @option args password [String] The password used to authenticate with the service.
     #   Username and password credentials are only required to run your
-    #   application locally or outside of Bluemix. When running on
-    #   Bluemix, the credentials will be automatically loaded from the
+    #   application locally or outside of IBM Cloud. When running on
+    #   IBM Cloud, the credentials will be automatically loaded from the
     #   `VCAP_SERVICES` environment variable.
     # @option args iam_apikey [String] An API key that can be used to request IAM tokens. If
     #   this API key is provided, the SDK will manage the token and handle the
@@ -76,7 +76,7 @@ module IBMWatson
     #   it expires or reactively upon receiving a 401 from the service as any requests
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
-    #   'https://iam.ng.bluemix.net/identity/token'.
+    #   'https://iam.cloud.ibm.com/identity/token'.
     def initialize(args = {})
       @__async_initialized__ = false
       defaults = {}
@@ -433,7 +433,7 @@ module IBMWatson
     # @param acoustic_customization_id [String] The GUID of a custom acoustic model that is to be used with the request. The base model of the specified custom acoustic model must match the model specified with the `model` parameter. You must make the request with service credentials created for the instance of the service that owns the custom model. By default, no custom acoustic model is used.
     # @param language_customization_id [String] The GUID of a custom language model that is to be used with the request. The base model of the specified custom language model must match the model specified with the `model` parameter. You must make the request with service credentials created for the instance of the service that owns the custom model. By default, no custom language model is used.
     # @param customization_weight [Float] If you specify a `customization_id` with the request, you can use the `customization_weight` parameter to tell the service how much weight to give to words from the custom language model compared to those from the base model for speech recognition.   Specify a value between 0.0 and 1.0. Unless a different customization weight was specified for the custom model when it was trained, the default value is 0.3. A customization weight that you specify overrides a weight that was specified when the custom model was trained.   The default value yields the best performance in general. Assign a higher value if your audio makes frequent use of OOV words from the custom model. Use caution when setting the weight: a higher value can improve the accuracy of phrases from the custom model's domain, but it can negatively affect performance on non-domain phrases.
-    # @param base_model_version [String] The version of the specified base `model` that is to be used for speech recognition. Multiple versions of a base model can exist when a model is updated for internal improvements. The parameter is intended primarily for use with custom models that have been upgraded for a new base model. The default value depends on whether the parameter is used with or without a custom model. For more information, see [Base model version](https://console.bluemix.net/docs/services/speech-to-text/input.html#version).
+    # @param base_model_version [String] The version of the specified base `model` that is to be used for speech recognition. Multiple versions of a base model can exist when a model is updated for internal improvements. The parameter is intended primarily for use with custom models that have been upgraded for a new base model. The default value depends on whether the parameter is used with or without a custom model. For more information, see [Base model version](https://cloud.ibm.com/docs/services/speech-to-text?topic=speech-to-text-input#version).
     # @param inactivity_timeout [Integer] The time in seconds after which, if only silence (no speech) is detected in submitted audio, the connection is closed with a 400 error. Useful for stopping audio submission from a live microphone when a user simply walks away. Use `-1` for infinity.
     # @param interim_results [Boolean] Send back non-final previews of each "sentence" as it is being processed. These results are ignored in text mode.
     # @param keywords [Array<String>] Array of keyword strings to spot in the audio. Each keyword string can include one or more tokens. Keywords are spotted only in the final hypothesis, not in interim results. If you specify any keywords, you must also specify a keywords threshold. Omit the parameter or specify an empty array if you do not need to spot keywords.
@@ -444,7 +444,7 @@ module IBMWatson
     # @param timestamps [Boolean] If `true`, time alignment for each word is returned.
     # @param profanity_filter [Boolean] If `true` (the default), filters profanity from all output except for keyword results by replacing inappropriate words with a series of asterisks. Set the parameter to `false` to return results with no censoring. Applies to US English transcription only.
     # @param smart_formatting [Boolean] If `true`, converts dates, times, series of digits and numbers, phone numbers, currency values, and Internet addresses into more readable, conventional representations in the final transcript of a recognition request. If `false` (the default), no formatting is performed. Applies to US English transcription only.
-    # @param speaker_labels [Boolean] Indicates whether labels that identify which words were spoken by which participants in a multi-person exchange are to be included in the response. The default is `false`; no speaker labels are returned. Setting `speaker_labels` to `true` forces the `timestamps` parameter to be `true`, regardless of whether you specify `false` for the parameter.   To determine whether a language model supports speaker labels, use the `GET /v1/models` method and check that the attribute `speaker_labels` is set to `true`. You can also refer to [Speaker labels](https://console.bluemix.net/docs/services/speech-to-text/output.html#speaker_labels).
+    # @param speaker_labels [Boolean] Indicates whether labels that identify which words were spoken by which participants in a multi-person exchange are to be included in the response. The default is `false`; no speaker labels are returned. Setting `speaker_labels` to `true` forces the `timestamps` parameter to be `true`, regardless of whether you specify `false` for the parameter.   To determine whether a language model supports speaker labels, use the `GET /v1/models` method and check that the attribute `speaker_labels` is set to `true`. You can also refer to [Speaker labels](https://cloud.ibm.com/docs/services/speech-to-text?topic=speech-to-text-output#speaker_labels).
     # @param grammar_name [String] The name of a grammar that is to be used with the recognition request. If you
     #   specify a grammar, you must also use the `language_customization_id` parameter to
     #   specify the name of the custom language model for which the grammar is defined.

--- a/lib/ibm_watson/text_to_speech_v1.rb
+++ b/lib/ibm_watson/text_to_speech_v1.rb
@@ -52,16 +52,16 @@ module IBMWatson
     # @param args [Hash] The args to initialize with
     # @option args url [String] The base url to use when contacting the service (e.g.
     #   "https://stream.watsonplatform.net/text-to-speech/api").
-    #   The base url may differ between Bluemix regions.
+    #   The base url may differ between IBM Cloud regions.
     # @option args username [String] The username used to authenticate with the service.
     #   Username and password credentials are only required to run your
-    #   application locally or outside of Bluemix. When running on
-    #   Bluemix, the credentials will be automatically loaded from the
+    #   application locally or outside of IBM Cloud. When running on
+    #   IBM Cloud, the credentials will be automatically loaded from the
     #   `VCAP_SERVICES` environment variable.
     # @option args password [String] The password used to authenticate with the service.
     #   Username and password credentials are only required to run your
-    #   application locally or outside of Bluemix. When running on
-    #   Bluemix, the credentials will be automatically loaded from the
+    #   application locally or outside of IBM Cloud. When running on
+    #   IBM Cloud, the credentials will be automatically loaded from the
     #   `VCAP_SERVICES` environment variable.
     # @option args iam_apikey [String] An API key that can be used to request IAM tokens. If
     #   this API key is provided, the SDK will manage the token and handle the
@@ -71,7 +71,7 @@ module IBMWatson
     #   it expires or reactively upon receiving a 401 from the service as any requests
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
-    #   'https://iam.ng.bluemix.net/identity/token'.
+    #   'https://iam.cloud.ibm.com/identity/token'.
     def initialize(args = {})
       @__async_initialized__ = false
       defaults = {}

--- a/lib/ibm_watson/tone_analyzer_v3.rb
+++ b/lib/ibm_watson/tone_analyzer_v3.rb
@@ -55,16 +55,16 @@ module IBMWatson
     #   ready for a later version.
     # @option args url [String] The base url to use when contacting the service (e.g.
     #   "https://gateway.watsonplatform.net/tone-analyzer/api").
-    #   The base url may differ between Bluemix regions.
+    #   The base url may differ between IBM Cloud regions.
     # @option args username [String] The username used to authenticate with the service.
     #   Username and password credentials are only required to run your
-    #   application locally or outside of Bluemix. When running on
-    #   Bluemix, the credentials will be automatically loaded from the
+    #   application locally or outside of IBM Cloud. When running on
+    #   IBM Cloud, the credentials will be automatically loaded from the
     #   `VCAP_SERVICES` environment variable.
     # @option args password [String] The password used to authenticate with the service.
     #   Username and password credentials are only required to run your
-    #   application locally or outside of Bluemix. When running on
-    #   Bluemix, the credentials will be automatically loaded from the
+    #   application locally or outside of IBM Cloud. When running on
+    #   IBM Cloud, the credentials will be automatically loaded from the
     #   `VCAP_SERVICES` environment variable.
     # @option args iam_apikey [String] An API key that can be used to request IAM tokens. If
     #   this API key is provided, the SDK will manage the token and handle the
@@ -74,7 +74,7 @@ module IBMWatson
     #   it expires or reactively upon receiving a 401 from the service as any requests
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
-    #   'https://iam.ng.bluemix.net/identity/token'.
+    #   'https://iam.cloud.ibm.com/identity/token'.
     def initialize(args = {})
       @__async_initialized__ = false
       defaults = {}

--- a/lib/ibm_watson/visual_recognition_v3.rb
+++ b/lib/ibm_watson/visual_recognition_v3.rb
@@ -47,7 +47,7 @@ module IBMWatson
     #   ready for a later version.
     # @option args url [String] The base url to use when contacting the service (e.g.
     #   "https://gateway.watsonplatform.net/visual-recognition/api").
-    #   The base url may differ between Bluemix regions.
+    #   The base url may differ between IBM Cloud regions.
     # @option args iam_apikey [String] An API key that can be used to request IAM tokens. If
     #   this API key is provided, the SDK will manage the token and handle the
     #   refreshing.
@@ -56,7 +56,7 @@ module IBMWatson
     #   it expires or reactively upon receiving a 401 from the service as any requests
     #   made with an expired token will fail.
     # @option args iam_url [String] An optional URL for the IAM service API. Defaults to
-    #   'https://iam.ng.bluemix.net/identity/token'.
+    #   'https://iam.cloud.ibm.com/identity/token'.
     def initialize(args = {})
       @__async_initialized__ = false
       defaults = {}

--- a/test/unit/test_language_translator_v3.rb
+++ b/test/unit/test_language_translator_v3.rb
@@ -9,14 +9,14 @@ WebMock.disable_net_connect!(allow_localhost: true)
 # Unit tests for the Language Translator V3 Service
 class LanguageTranslatorV3Test < Minitest::Test
   def test_translate_source_target
-    stub_request(:post, "https://iam.bluemix.net/identity/token")
+    stub_request(:post, "https://iam.cloud.ibm.com/identity/token")
       .with(
         body: { "apikey" => "iam_apikey", "grant_type" => "urn:ibm:params:oauth:grant-type:apikey", "response_type" => "cloud_iam" },
         headers: {
           "Accept" => "application/json",
           "Authorization" => "Basic Yng6Yng=",
           "Content-Type" => "application/x-www-form-urlencoded",
-          "Host" => "iam.bluemix.net"
+          "Host" => "iam.cloud.ibm.com"
         }
       ).to_return(
         status: 200,
@@ -57,14 +57,14 @@ class LanguageTranslatorV3Test < Minitest::Test
   end
 
   def test_translate_model_id
-    stub_request(:post, "https://iam.bluemix.net/identity/token")
+    stub_request(:post, "https://iam.cloud.ibm.com/identity/token")
       .with(
         body: { "apikey" => "iam_apikey", "grant_type" => "urn:ibm:params:oauth:grant-type:apikey", "response_type" => "cloud_iam" },
         headers: {
           "Accept" => "application/json",
           "Authorization" => "Basic Yng6Yng=",
           "Content-Type" => "application/x-www-form-urlencoded",
-          "Host" => "iam.bluemix.net"
+          "Host" => "iam.cloud.ibm.com"
         }
       ).to_return(
         status: 200,
@@ -108,14 +108,14 @@ class LanguageTranslatorV3Test < Minitest::Test
   end
 
   def test_identify
-    stub_request(:post, "https://iam.bluemix.net/identity/token")
+    stub_request(:post, "https://iam.cloud.ibm.com/identity/token")
       .with(
         body: { "apikey" => "iam_apikey", "grant_type" => "urn:ibm:params:oauth:grant-type:apikey", "response_type" => "cloud_iam" },
         headers: {
           "Accept" => "application/json",
           "Authorization" => "Basic Yng6Yng=",
           "Content-Type" => "application/x-www-form-urlencoded",
-          "Host" => "iam.bluemix.net"
+          "Host" => "iam.cloud.ibm.com"
         }
       ).to_return(
         status: 200,
@@ -165,14 +165,14 @@ class LanguageTranslatorV3Test < Minitest::Test
   end
 
   def test_list_identifiable_languages
-    stub_request(:post, "https://iam.bluemix.net/identity/token")
+    stub_request(:post, "https://iam.cloud.ibm.com/identity/token")
       .with(
         body: { "apikey" => "iam_apikey", "grant_type" => "urn:ibm:params:oauth:grant-type:apikey", "response_type" => "cloud_iam" },
         headers: {
           "Accept" => "application/json",
           "Authorization" => "Basic Yng6Yng=",
           "Content-Type" => "application/x-www-form-urlencoded",
-          "Host" => "iam.bluemix.net"
+          "Host" => "iam.cloud.ibm.com"
         }
       ).to_return(
         status: 200,
@@ -230,14 +230,14 @@ class LanguageTranslatorV3Test < Minitest::Test
   end
 
   def test_create_model
-    stub_request(:post, "https://iam.bluemix.net/identity/token")
+    stub_request(:post, "https://iam.cloud.ibm.com/identity/token")
       .with(
         body: { "apikey" => "iam_apikey", "grant_type" => "urn:ibm:params:oauth:grant-type:apikey", "response_type" => "cloud_iam" },
         headers: {
           "Accept" => "application/json",
           "Authorization" => "Basic Yng6Yng=",
           "Content-Type" => "application/x-www-form-urlencoded",
-          "Host" => "iam.bluemix.net"
+          "Host" => "iam.cloud.ibm.com"
         }
       ).to_return(
         status: 200,
@@ -300,14 +300,14 @@ class LanguageTranslatorV3Test < Minitest::Test
   end
 
   def test_delete_model
-    stub_request(:post, "https://iam.bluemix.net/identity/token")
+    stub_request(:post, "https://iam.cloud.ibm.com/identity/token")
       .with(
         body: { "apikey" => "iam_apikey", "grant_type" => "urn:ibm:params:oauth:grant-type:apikey", "response_type" => "cloud_iam" },
         headers: {
           "Accept" => "application/json",
           "Authorization" => "Basic Yng6Yng=",
           "Content-Type" => "application/x-www-form-urlencoded",
-          "Host" => "iam.bluemix.net"
+          "Host" => "iam.cloud.ibm.com"
         }
       ).to_return(
         status: 200,
@@ -342,14 +342,14 @@ class LanguageTranslatorV3Test < Minitest::Test
   end
 
   def test_get_model
-    stub_request(:post, "https://iam.bluemix.net/identity/token")
+    stub_request(:post, "https://iam.cloud.ibm.com/identity/token")
       .with(
         body: { "apikey" => "iam_apikey", "grant_type" => "urn:ibm:params:oauth:grant-type:apikey", "response_type" => "cloud_iam" },
         headers: {
           "Accept" => "application/json",
           "Authorization" => "Basic Yng6Yng=",
           "Content-Type" => "application/x-www-form-urlencoded",
-          "Host" => "iam.bluemix.net"
+          "Host" => "iam.cloud.ibm.com"
         }
       ).to_return(
         status: 200,
@@ -393,14 +393,14 @@ class LanguageTranslatorV3Test < Minitest::Test
   end
 
   def test_list_models
-    stub_request(:post, "https://iam.bluemix.net/identity/token")
+    stub_request(:post, "https://iam.cloud.ibm.com/identity/token")
       .with(
         body: { "apikey" => "iam_apikey", "grant_type" => "urn:ibm:params:oauth:grant-type:apikey", "response_type" => "cloud_iam" },
         headers: {
           "Accept" => "application/json",
           "Authorization" => "Basic Yng6Yng=",
           "Content-Type" => "application/x-www-form-urlencoded",
-          "Host" => "iam.bluemix.net"
+          "Host" => "iam.cloud.ibm.com"
         }
       ).to_return(
         status: 200,


### PR DESCRIPTION
This pull request refactors bluemix to cloud.ibm with the exception of example files and links to apps running in bluemix.