### PR TITLE
fix(stt): typo in recognize_websocket

### DIFF
--- a/lib/ibm_watson/speech_to_text_v1.rb
+++ b/lib/ibm_watson/speech_to_text_v1.rb
@@ -554,7 +554,7 @@ module IBMWatson
       params = {
         "model" => model,
         "customization_id" => customization_id,
-        "langauge_customization_id" => language_customization_id,
+        "language_customization_id" => language_customization_id,
         "acoustic_customization_id" => acoustic_customization_id,
         "customization_weight" => customization_weight,
         "base_model_version" => base_model_version


### PR DESCRIPTION
Fixes https://github.com/watson-developer-cloud/ruby-sdk/issues/69