### PR TITLE
Update gateway url to onecloud [skip ci]

### DIFF
--- a/resources/vcap-testing.json
+++ b/resources/vcap-testing.json
@@ -3,7 +3,7 @@
   	{
   		"credentials": {
   			"password": "password",
-  			"url": "https://gateway-wdc.watsonplatform.net/personality-insights/api",
+  			"url": "https://api.us-east.personality-insights.watson.cloud.ibm.com",
   			"username": "username"
   		},
   		"label": "personality",


### PR DESCRIPTION
Watsonplatform.net urls will cease to function starting 12 Feb 2021. This pull request replaces the gateway url with the onecloud equivalent.