### PR TITLE
fix: update http gem to 4.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Ruby gem to quickly get started with the various [IBM Watson][wdc] services.
 </details>
 
 ## ANNOUNCEMENTS!
+### Support for 2.7 ruby
+To support 2.7 the http gem dependency is updated to 4.4.0. Since it conflicted with the dependency in the ruby-sdk-core that gem was also updated.  Using 2.0.2 or above ruby sdk will require a core of 1.1.3 or above.
+
 ### Updating endpoint URLs from watsonplatform.net
 Watson API endpoint URLs at watsonplatform.net are changing and will not work after 26 May 2021. Update your calls to use the newer endpoint URLs. For more information, see https://cloud.ibm.com/docs/watson?topic=watson-endpoint-change.
 

--- a/ibm_watson.gemspec
+++ b/ibm_watson.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
   spec.add_runtime_dependency "eventmachine", "~> 1.2"
   spec.add_runtime_dependency "faye-websocket", "~> 0.11"
-  spec.add_runtime_dependency "http", "~> 4.1.0"
+  spec.add_runtime_dependency "http", "~> 4.4.0"
   spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.1.1"
   spec.add_runtime_dependency "jwt", "~> 2.2.1"
 

--- a/ibm_watson.gemspec
+++ b/ibm_watson.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "eventmachine", "~> 1.2"
   spec.add_runtime_dependency "faye-websocket", "~> 0.11"
   spec.add_runtime_dependency "http", "~> 4.4.0"
-  spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.1.1"
+  spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.1.3"
   spec.add_runtime_dependency "jwt", "~> 2.2.1"
 
   spec.add_development_dependency "bundler", "~> 2.2"


### PR DESCRIPTION
2.7 ruby

Moses Mendoza came across this fix for 2.7 ruby that references the frozen string error.
This PR updates the http gem dependency to 4.4.0.  Since it conflicted with the dependency in the ruby-sdk-core that gem was also updated.

